### PR TITLE
feat!: drop Python 3.7 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ It also allows you to verify a string quickly by providing commonly used regex p
 Quick Start
 =============
 
-To get started make sure you have Python 3.7-3.14 installed and then, install Edify from ``pip``:
+To get started make sure you have Python 3.8-3.14 installed and then, install Edify from ``pip``:
 
 .. code-block:: bash
 

--- a/ci/templates/.appveyor.yml
+++ b/ci/templates/.appveyor.yml
@@ -4,9 +4,9 @@ image: Visual Studio 2019
 environment:
   matrix:
     - TOXENV: check
-      TOXPYTHON: C:\Python36\python.exe
-      PYTHON_HOME: C:\Python36
-      PYTHON_VERSION: '3.6'
+      TOXPYTHON: C:\Python38\python.exe
+      PYTHON_HOME: C:\Python38
+      PYTHON_VERSION: '3.8'
       PYTHON_ARCH: '32'
 {% for env in tox_environments %}
 {% if env.startswith(('py2', 'py3')) %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,5 @@ requires = [
 
 [tool.black]
 line-length = 140
-target-version = ['py37']
+target-version = ['py38']
 skip-string-normalization = true

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
@@ -70,7 +69,7 @@ setup(
     keywords=[
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     install_requires=[
         # eg: 'aspectlib==1.1.1', 'six>=1.7',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -14,15 +14,13 @@ envlist =
     clean,
     check,
     docs,
-    {py37,py38,py39,py310,py311,py312,py313,py314,pypy37,pypy38},
+    {py38,py39,py310,py311,py312,py313,py314,pypy38},
     report
 ignore_basepython_conflict = true
 
 [testenv]
 basepython =
-    pypy37: {env:TOXPYTHON:pypy3.7}
     pypy38: {env:TOXPYTHON:pypy3.8}
-    py37: {env:TOXPYTHON:python3.7}
     py38: {env:TOXPYTHON:python3.8}
     py39: {env:TOXPYTHON:python3.9}
     py310: {env:TOXPYTHON:python3.10}


### PR DESCRIPTION
## Summary

Python 3.7 reached end-of-life on 2023-06-27. Copilot dropped 3.7 from the CI matrix in #30 but left the rest of the project metadata pointing at it. This PR finishes the job so 3.8 is the consistent floor everywhere.

## Changes

- [`setup.py`](../blob/drop-python-3.7-support/setup.py): drop the `Programming Language :: Python :: 3.7` classifier and bump `python_requires` to `>=3.8`.
- [`pyproject.toml`](../blob/drop-python-3.7-support/pyproject.toml): bump black `target-version` to `py38`.
- [`tox.ini`](../blob/drop-python-3.7-support/tox.ini): drop the `py37` and `pypy37` envs from `envlist` and their `basepython` entries.
- [`README.rst`](../blob/drop-python-3.7-support/README.rst): update the quick-start to "Python 3.8-3.14".
- [`ci/templates/.appveyor.yml`](../blob/drop-python-3.7-support/ci/templates/.appveyor.yml): bump the `check` env from Python 3.6 → 3.8 so the template's floor matches the project's. Template only — not currently rendered into a live AppVeyor config.

PyPy 3.8 is end-of-life as of October 2024, but I've intentionally left it in this PR so the diff stays scoped to "drop 3.7." It will be cleaned up in a follow-up PR that refreshes the PyPy CI matrix.

**BREAKING CHANGE:** Edify now requires Python 3.8 or newer. The next release will be `0.3.0`.

## Test plan

- [ ] CI matrix passes on all of py38, py39, py310, py311, py312, py313, py314, and pypy38.
- [ ] `check` and `docs` tox envs pass.