### PR TITLE
chore: modernize pre-commit hook configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,20 +5,20 @@
 exclude: '^(\.tox|ci/templates|\.bumpversion\.cfg)(/|$)'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: main
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: debug-statements
-  - repo: https://github.com/timothycrosley/isort
-    rev: main
+  - repo: https://github.com/PyCQA/isort
+    rev: 8.0.1
     hooks:
       - id: isort
-  - repo: https://github.com/psf/black
-    rev: main
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 26.3.1
     hooks:
       - id: black
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: master
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.3.0
     hooks:
       - id: flake8


### PR DESCRIPTION
## Summary

`.pre-commit-config.yaml` was broken on three fronts. This PR fixes all of them.

### What was wrong

1. **`rev: main` / `rev: master`** — modern pre-commit rejects floating refs and requires immutable tags (or a SHA) so hook versions are reproducible across contributors. Every hook in the file had this.
2. **Dead repo URLs.**
   - `gitlab.com/pycqa/flake8` was archived years ago. `flake8` now lives at [`github.com/PyCQA/flake8`](https://github.com/PyCQA/flake8).
   - `timothycrosley/isort` was renamed to [`PyCQA/isort`](https://github.com/PyCQA/isort) and the old org redirect can't be relied on for hooks.
3. **`psf/black`** still works, but the upstream-recommended hook source is now [`psf/black-pre-commit-mirror`](https://github.com/psf/black-pre-commit-mirror), which ships without black's full dependency tree → significantly faster hook installs.

### Pinned versions

| Hook | Old | New |
|---|---|---|
| `pre-commit/pre-commit-hooks` | `main` | `v6.0.0` |
| `PyCQA/isort` (was `timothycrosley/isort`) | `main` | `8.0.1` |
| `psf/black-pre-commit-mirror` (was `psf/black`) | `main` | `26.3.1` |
| `PyCQA/flake8` (was `gitlab.com/pycqa/flake8`) | `master` | `7.3.0` |

All four are the latest stable releases as of this PR.

## Notes

- Hooks run in pre-commit's own isolated venvs, so the linter Pythons don't have to match the project's `python_requires=>=3.8` floor.
- The existing `[flake8]` config in `setup.cfg` (`max-line-length = 140`, exclusions) is unchanged and still applies.
- pre-commit.ci was discussed but intentionally left out of this PR to keep scope narrow. Easy follow-up if we want it.

## Test plan

- [ ] CI `check` env still passes (it runs `flake8` and `isort --check-only` directly via tox, not via pre-commit, so this PR shouldn't affect it).
- [ ] `pre-commit run --all-files` works locally on a fresh checkout (hooks install from the new revs).