### PR TITLE
chore: bump GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,4 +69,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,8 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/checkout@v5
+    - uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: install dependencies

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -156,10 +156,10 @@ jobs:
             tox_env: 'py314'
             os: 'macos-latest'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
         architecture: ${{ matrix.python_arch }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -33,7 +33,7 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d  # v1.14.0
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary

Pure version bumps for the four GitHub Actions referenced under `.github/workflows/`. No behavior change — actions are pinned to current majors (or the current SHA, in the case of the third-party publish action).

| File | Action | Before | After |
|---|---|---|---|
| `github-actions.yml`, `coverage.yml`, `python-publish.yml`, `codeql-analysis.yml` | `actions/checkout` | `@v3` | `@v5` |
| `github-actions.yml`, `coverage.yml`, `python-publish.yml` | `actions/setup-python` | `@v3` | `@v5` |
| `codeql-analysis.yml` | `github/codeql-action/{init,autobuild,analyze}` | `@v2` | `@v3` |
| `python-publish.yml` | `pypa/gh-action-pypi-publish` | old SHA | `v1.14.0` SHA + version comment |

## Why now

The `@v3` actions ran on the **Node 16 runtime**, which reached end-of-life in 2023 and is on borrowed time on GitHub-hosted runners. `@v5` (and `codeql-action @v3`) all use Node 20, the current supported runtime. We were also missing security/bug fixes shipped in newer majors.

## Conventions used

- First-party actions (`actions/*`, `github/*`) → floating major-version tag (`@v5`, `@v3`). Standard for first-party, low supply-chain risk.
- Third-party action (`pypa/gh-action-pypi-publish`) → stays SHA-pinned for supply-chain safety. The trailing `# v1.14.0` comment makes the human-readable version visible without sacrificing the immutable pin.

Closes #34