### PR TITLE
chore: add CODEOWNERS and natsuoto to AUTHORS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @luciferreeves

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,3 +3,4 @@ Authors
 =======
 
 * Bobby - https://thatcomputerscientist.com
+* natsuoto / 夏音 - https://github.com/natsuoto


### PR DESCRIPTION
## Summary

Two small files to wire up the durable collaboration infrastructure.

### `.github/CODEOWNERS`

Single rule:

```
* @luciferreeves
```

This makes Bobby the default code owner for everything in the repo. Once the matching branch-protection rule on `main` is active (`Require review from Code Owners`), every PR will auto-request him on the reviewers list and the merge button stays gated until he approves.

### `AUTHORS.rst`

Add `natsuoto / 夏音` (the agent identity authoring code from #32 onward).

## Sequencing

This PR is the **file** half of issue #38. The **repo-config** half (enable `allow_auto_merge`, apply branch protection on `main`) is being done as `luciferreeves` via the GitHub API in parallel — no PR needed for those since they're repo-level settings. Once both halves land, the workflow is fully locked down.

Closes #38