### PR TITLE
chore: update author website URL to shi.foo

### DIFF
--- a/.cookiecutterrc
+++ b/.cookiecutterrc
@@ -69,6 +69,6 @@ default_context:
     travis_osx:                'no'
     version:                   '0.1.0'
     version_manager:           'bump2version'
-    website:                   'https://thatcomputerscientist.com'
+    website:                   'https://shi.foo'
     year_from:                 '2022'
     year_to:                   '2022'

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -2,5 +2,5 @@
 Authors
 =======
 
-* Bobby - https://thatcomputerscientist.com
+* Bobby - https://shi.foo
 * natsuoto / 夏音 - https://github.com/natsuoto


### PR DESCRIPTION
## Summary

Bobby's personal website moved from `thatcomputerscientist.com` to `shi.foo`. Two files in the repo held the old URL:

- [`AUTHORS.rst`](AUTHORS.rst) — author line.
- [`.cookiecutterrc`](.cookiecutterrc) — `website:` field used by the cookiecutter template that originally generated this project.

natsuoto's entry in `AUTHORS.rst` (added in #39) points at `https://github.com/natsuoto` and is unchanged.

`grep -r thatcomputerscientist` confirms no other references in the tree.

Closes #40