### PR TITLE
chore(release): bump version to 0.3.0 (no release yet)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.2
+current_version = 0.3.0
 commit = True
 tag = True
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,45 @@
 
 Changelog
 =========
-Unreleased
-----------
-* Added support for Python 3.14.
-* Updated Read the Docs build configuration.
+0.3.0 (unreleased)
+------------------
+
+A maintenance release: Edify is dragged out of 2022 and back into modern shape. No new patterns or builder API. The minimum supported Python rises to 3.8.
+
+Breaking
+~~~~~~~~
+
+* Dropped support for Python 3.7. Edify now requires Python 3.8 or newer (:pr:`32`).
+
+Added
+~~~~~
+
+* Support for Python 3.12, 3.13, and 3.14, with the matrix and Read the Docs build configuration updated to match (:pr:`31`).
+
+Tooling and CI
+~~~~~~~~~~~~~~
+
+* Bumped GitHub Actions to current major versions: ``actions/checkout@v5``, ``actions/setup-python@v5``, ``github/codeql-action@v3``. All workflow jobs now run on the Node 20 runtime instead of the deprecated Node 16. ``pypa/gh-action-pypi-publish`` SHA refreshed to ``v1.14.0`` (:pr:`35`).
+* PyPy CI matrix moved off the EOL ``pypy-3.8`` line to the maintained ``pypy-3.10`` and ``pypy-3.11`` (:pr:`37`).
+* ``.pre-commit-config.yaml`` modernised: every hook pinned to an immutable tag instead of a floating branch ref, dead repo URLs corrected (``gitlab.com/pycqa/flake8`` → ``github.com/PyCQA/flake8``, ``timothycrosley/isort`` → ``PyCQA/isort``), and ``psf/black`` swapped for the upstream-recommended ``psf/black-pre-commit-mirror`` (:pr:`33`).
+
+Dependencies
+~~~~~~~~~~~~
+
+* Bumped minimum versions: ``setuptools >=75.0``, ``pip >=26.0.1``, ``virtualenv >=21.3.0``, ``six >=1.17.0``, ``sphinx >=7.4.7`` (:pr:`25`, :pr:`26`, :pr:`27`, :pr:`28`, :pr:`29`).
+
+Repository infrastructure
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Added ``.github/CODEOWNERS`` and ``natsuoto`` to ``AUTHORS.rst`` for the new agent-driven contribution flow (:pr:`39`).
+* Locked ``main``: 1 approving code-owner review required, 31 status-check contexts required (the full matrix), linear history enforced, no force pushes or deletions, applies to administrators.
+* Repo-level ``allow_auto_merge`` enabled — PRs auto-merge once review and CI gates pass.
+
+Housekeeping
+~~~~~~~~~~~~
+
+* Dropped a dead ``py37``/``pypy37`` exclusion from the cookiecutter Jinja template and refreshed the docs copyright year (:pr:`43`).
+* Updated author website URL in ``AUTHORS.rst`` and ``.cookiecutterrc`` (:pr:`41`).
 
 0.2.2 (2022-12-22)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -36,9 +36,9 @@ Edify
     :alt: Supported implementations
     :target: https://pypi.org/project/edify
 
-.. image:: https://img.shields.io/github/commits-since/luciferreeves/edify/v0.2.2.svg
+.. image:: https://img.shields.io/github/commits-since/luciferreeves/edify/v0.3.0.svg
     :alt: Commits since latest release
-    :target: https://github.com/luciferreeves/edify/compare/v0.2.2...main
+    :target: https://github.com/luciferreeves/edify/compare/v0.3.0...main
 
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,14 +20,21 @@ project = 'Edify'
 year = '2022-2026'
 author = 'Bobby'
 copyright = '{0}, {1}'.format(year, author)
-version = release = '0.2.2'
+version = release = '0.3.0'
 
 pygments_style = 'trac'
 templates_path = ['.']
 extlinks = {
-    'issue': ('https://github.com/luciferreeves/edify/issues/%s', '#'),
-    'pr': ('https://github.com/luciferreeves/edify/pull/%s', 'PR #'),
+    'issue': ('https://github.com/luciferreeves/edify/issues/%s', '#%s'),
+    'pr': ('https://github.com/luciferreeves/edify/pull/%s', 'PR #%s'),
 }
+# The "commits since latest release" shield in README.rst targets a
+# `compare/vX.Y.Z...main` URL, which 404s during the window between
+# bumping the version and tagging the release. Skip it in linkcheck
+# rather than letting docs CI fail every time we bump.
+linkcheck_ignore = [
+    r'https://github\.com/luciferreeves/edify/compare/v\d+\.\d+\.\d+\.\.\.main',
+]
 # on_rtd is whether we are on readthedocs.org
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def read(*names, **kwargs):
 
 setup(
     name='edify',
-    version='0.2.2',
+    version='0.3.0',
     license='Apache-2.0',
     description='Regular Expressions Made Simple',
     long_description='{}\n{}'.format(

--- a/src/edify/__init__.py
+++ b/src/edify/__init__.py
@@ -1,4 +1,4 @@
 # flake8: noqa
 
-__version__ = '0.2.2'
+__version__ = '0.3.0'
 from .builder.builder import RegexBuilder


### PR DESCRIPTION
## Summary

Park version metadata at **0.3.0**. The changelog header stays `0.3.0 (unreleased)` — this is **not** the release. More features will land before we actually tag.

## Files

- `setup.py`, `docs/conf.py`, `src/edify/__init__.py`, `.bumpversion.cfg`: `0.2.2` → `0.3.0`.
- `README.rst`: both `commits-since/v0.2.2` shield URLs → `v0.3.0`. The shield will 404 until `v0.3.0` is actually tagged — accepted trade-off so `bumpversion`'s `search = /v{current_version}.svg` rule stays valid for the next bump.
- `CHANGELOG.rst`: replace Copilot's stub `Unreleased` heading with a real `0.3.0 (unreleased)` entry. Categorised: Breaking, Added, Tooling and CI, Dependencies, Repository infrastructure, Housekeeping. References every PR that landed on this version line.
- `docs/conf.py`: fix `extlinks` caption format. The old caption style (a bare prefix like `'PR #'`) was deprecated in Sphinx 5 and removed in 6, but stayed latent because no CHANGELOG entry was using `:pr:` or `:issue:`. The new changelog uses `:pr:` for every cross-reference, which is what surfaced the docs-CI failure on the first run of this PR. Updated to `'PR #%s'` / `'#%s'`.

## Sequencing

Rebased onto current `main` (which now has #41 and #43 merged). Auto-merge is queued (rebase strategy).

Closes #44