### PR TITLE
fix(docs): drop PDF and EPUB builds from RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,6 @@ build:
     python: "3.14"
 sphinx:
   configuration: docs/conf.py
-formats: all
 python:
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
## Summary

RTD has been failing the build pipeline for `latest` because the PDF format can't be produced. HTML and htmlzip succeed; PDF fails on `pdflatex`'s inability to render the README's SVG badges or the IPA Unicode in the project pronunciation, leaves a damaged output, and RTD's uploader refuses with *"Build output directory for format 'pdf' contains multiple files."*

This drops the `formats: all` line from `.readthedocs.yml`, which defaults RTD back to HTML-only.

Re-introducing PDF would require switching the LaTeX engine to `xelatex`/`lualatex` and hiding every README badge behind `.. only:: html` directives, with the standing risk that any new badge or non-ASCII character re-breaks it. PDFs of a regex-builder library aren't worth that maintenance bill.

If the htmlzip download specifically is missed, that's a one-line follow-up: `formats: [htmlzip]`.

Closes #48