### PR TITLE
chore(release): date 0.3.0 changelog entry

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 
 Changelog
 =========
-0.3.0 (unreleased)
+0.3.0 (2026-04-29)
 ------------------
 
 A maintenance release: Edify is dragged out of 2022 and back into modern shape. No new patterns or builder API. The minimum supported Python rises to 3.8.


### PR DESCRIPTION
## Summary

One-line change: `0.3.0 (unreleased)` → `0.3.0 (2026-04-29)`. Stamps the changelog with the release date so it's ready to be the body of the GitHub release we cut after this lands.

No metadata changes — version was bumped to 0.3.0 in #45 and has been parked there since. This is purely the changelog header date.

## After merge

1. Sync `main` locally.
2. Create GitHub release tagged `v0.3.0` with the relevant changelog section as release notes.
3. The `Upload Python Package` workflow runs on `release: published` and uploads to PyPI via the existing `PYPI_API_TOKEN` secret.
4. Confirm `edify==0.3.0` is live on PyPI.

Closes #50