### PR TITLE
hotfix: pin pypa/gh-action-pypi-publish to commit SHA not tag-object SHA

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,6 +11,7 @@ name: Upload Python Package
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -33,7 +34,7 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d  # v1.14.0
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Symptom

The v0.3.0 publish workflow failed at the Docker image pull step:

> docker: Error response from daemon: manifest unknown
> ghcr.io/pypa/gh-action-pypi-publish:6733eb7d741f0b11ec6a39b58540dab7590f9b7d

PyPI upload didn't happen. v0.3.0 tag and GitHub release exist, but the package is not yet on PyPI.

## Root cause

#35 pinned `pypa/gh-action-pypi-publish` to `6733eb7d741f0b11ec6a39b58540dab7590f9b7d`. That's the **tag-object SHA** for v1.14.0, not the **commit SHA** the tag points to. Annotated tags have their own SHA which dereferences to a commit, and I used `.object.sha` from `git/refs/tags/v1.14.0` directly without checking `.object.type` (which was `tag`, not `commit`).

The actual v1.14.0 commit SHA is `cef221092ed1bacb1cc03d23a2d87d1d172e277b` (verified by following the tag object, and cross-checked against `refs/heads/release/v1` which points at the same commit).

Docker images for the publish action are tagged with the *commit* SHA, not the tag-object SHA, hence "manifest unknown."

## Fix

Two changes to `.github/workflows/python-publish.yml`:

1. SHA bump: `6733eb7d…` → `cef221092…` (still v1.14.0, just the right SHA this time).
2. Add `workflow_dispatch:` trigger so we can manually re-run publish after merge without deleting/recreating the release.

## After merge

Run `gh workflow run python-publish.yml` to dispatch the fixed workflow against `main`. The package contents are identical to what's at the v0.3.0 tag (we only changed the workflow file), so PyPI gets `edify==0.3.0` as intended.

Closes #52