### PR TITLE
chore: gitignore design_docs/ working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ docs/_build
 
 # Codecov Binary
 codecov
+
+# Design Docs
+design_docs


### PR DESCRIPTION
## Summary

Adds `design_docs/` to `.gitignore`. The directory is a local working space for collaborative design notes between Bobby and Claude (currently holds the 1.0 design doc) — its contents are intentionally local-only, not user-facing documentation.

Without this line, the contents are at risk of being accidentally tracked or committed during routine `git add` operations.

The single commit on this branch (`49297e1`) was authored and GPG-signed locally; the PR just lands it on `main` via the standard issue+PR flow.

Closes #65