### PR TITLE
feat: add Pattern class and .use() composition

### DIFF
--- a/edify/__init__.py
+++ b/edify/__init__.py
@@ -3,6 +3,7 @@ import importlib.metadata
 from edify.builder.builder import RegexBuilder
 from edify.errors.base import EdifyError
 from edify.errors.syntax import EdifySyntaxError
+from edify.pattern.composition import Pattern
 
 
 def _resolve_installed_version() -> str:
@@ -18,6 +19,7 @@ __version__ = _resolve_installed_version()
 __all__ = [
     "EdifyError",
     "EdifySyntaxError",
+    "Pattern",
     "RegexBuilder",
     "__version__",
 ]

--- a/edify/builder/core.py
+++ b/edify/builder/core.py
@@ -1,0 +1,30 @@
+"""Shared immutable-state plumbing for :class:`RegexBuilder` and :class:`Pattern`.
+
+Both fluent surfaces carry the same :class:`BuilderState` and use the same
+clone-and-replace pattern for chain methods. :class:`BuilderCore` provides
+the state attribute, the constructor, and the ``_with_state`` helper that
+mixins call to produce new instances; concrete classes compose it with
+their mixin set.
+"""
+
+from __future__ import annotations
+
+from typing import Self
+
+from edify.builder.types.state import BuilderState
+
+
+class BuilderCore:
+    """Holds the immutable :class:`BuilderState` and clones it on chain steps."""
+
+    _state: BuilderState
+
+    def __init__(self) -> None:
+        self._state = BuilderState()
+
+    def _with_state(self, new_state: BuilderState) -> Self:
+        """Return a fresh instance of the same concrete type carrying ``new_state``."""
+        concrete_class = type(self)
+        new_instance = concrete_class.__new__(concrete_class)
+        new_instance._state = new_state
+        return new_instance

--- a/edify/builder/mixins/subexpression.py
+++ b/edify/builder/mixins/subexpression.py
@@ -1,9 +1,15 @@
 """The :class:`SubexpressionMixin` — merge another builder as a quantifiable atom.
 
-Validates the incoming expression, transforms its elements through the
-namespace / capture-offset / anchor logic in :mod:`edify.builder.merge`,
-wraps the merged children in a :class:`SubexpressionElement`, and appends
-that to the current frame (applying any pending quantifier).
+Provides both :meth:`SubexpressionMixin.subexpression` (the primitive with
+full option surface) and :meth:`SubexpressionMixin.use` (the ergonomic
+alias that composes a :class:`edify.pattern.Pattern` or another builder
+with the common-case defaults).
+
+Both entry points validate the incoming expression, transform its elements
+through the namespace / capture-offset / anchor logic in
+:mod:`edify.builder.merge`, wrap the merged children in a
+:class:`SubexpressionElement`, and append that to the current frame
+(applying any pending quantifier).
 """
 
 from __future__ import annotations
@@ -19,7 +25,22 @@ from edify.errors.structure import CannotCallSubexpressionError
 
 
 class SubexpressionMixin(BuilderProtocol):
-    """Provides the ``.subexpression`` chain method."""
+    """Provides the ``.subexpression`` and ``.use`` chain methods."""
+
+    def use(self, pattern: BuilderProtocol) -> Self:
+        """Return a new builder with ``pattern`` embedded via subexpression semantics.
+
+        Ergonomic alias for ``self.subexpression(pattern)`` using the
+        common-case defaults (``ignore_flags=True``, ``ignore_start_and_end=True``,
+        no namespace). Use :meth:`subexpression` directly when you need to
+        override any of those.
+
+        Args:
+            pattern: A :class:`edify.pattern.Pattern` — or any fully-specified
+                fluent surface conforming to :class:`BuilderProtocol` — to
+                embed at the current position.
+        """
+        return self.subexpression(pattern)
 
     def subexpression(
         self,

--- a/edify/pattern/__init__.py
+++ b/edify/pattern/__init__.py
@@ -1,0 +1,3 @@
+from edify.pattern.composition import Pattern
+
+__all__ = ["Pattern"]

--- a/edify/pattern/composition.py
+++ b/edify/pattern/composition.py
@@ -1,13 +1,14 @@
-"""The composition root for :class:`RegexBuilder` — the fluent regex-builder class.
+"""The composition root for :class:`Pattern` — a reusable regex fragment.
 
-The class itself defines no chain methods; every method comes from one of
-the mixins under :mod:`edify.builder.mixins`. The composition order does
-not matter for behavior because the mixins do not override each other's
-methods, but they are listed alphabetically by mixin name for predictability.
+:class:`Pattern` shares every chain-method mixin with :class:`RegexBuilder`
+except the terminals: a pattern is not intended to compile itself, it is
+intended to compose *into* a builder (or into another pattern) via
+``.use()`` or ``.subexpression()``. To emit a regex from a pattern, embed it
+in a builder: ``RegexBuilder().use(my_pattern).to_regex()``.
 
 The immutable-state plumbing (``_state`` attribute + ``_with_state`` helper)
-lives on :class:`edify.builder.core.BuilderCore`, which every fluent surface
-in the package inherits from.
+comes from :class:`edify.builder.core.BuilderCore`, the same base
+:class:`edify.builder.builder.RegexBuilder` inherits from.
 """
 
 from __future__ import annotations
@@ -23,10 +24,9 @@ from edify.builder.mixins.flags import FlagsMixin
 from edify.builder.mixins.groups import GroupsMixin
 from edify.builder.mixins.quantifiers import QuantifiersMixin
 from edify.builder.mixins.subexpression import SubexpressionMixin
-from edify.builder.mixins.terminals import TerminalsMixin
 
 
-class RegexBuilder(
+class Pattern(
     BuilderCore,
     AnchorsMixin,
     AssertionsMixin,
@@ -38,6 +38,5 @@ class RegexBuilder(
     GroupsMixin,
     QuantifiersMixin,
     SubexpressionMixin,
-    TerminalsMixin,
 ):
-    """A fluent, immutable, strongly-typed regex builder."""
+    """A named, reusable regex fragment. Composes into a builder via ``.use()``."""

--- a/tests/builder/use.test.py
+++ b/tests/builder/use.test.py
@@ -1,0 +1,30 @@
+"""Tests for the ``.use(pattern)`` chain method on :class:`RegexBuilder`."""
+
+from edify import Pattern, RegexBuilder
+
+
+def test_use_embeds_a_pattern_at_the_current_position():
+    username = Pattern().between(3, 20).word()
+    expression = RegexBuilder().string("User ").use(username)
+    assert expression.to_regex_string() == "User \\w{3,20}"
+
+
+def test_use_composes_multiple_patterns_in_sequence():
+    first_pattern = Pattern().exactly(3).digit()
+    second_pattern = Pattern().char("-")
+    third_pattern = Pattern().exactly(4).digit()
+    expression = RegexBuilder().use(first_pattern).use(second_pattern).use(third_pattern)
+    assert expression.to_regex_string() == "\\d{3}\\-\\d{4}"
+
+
+def test_use_drops_the_pattern_flag_snapshot_by_default():
+    case_insensitive_pattern = Pattern().ignore_case().string("hello")
+    expression = RegexBuilder().use(case_insensitive_pattern)
+    compiled = expression.to_regex()
+    assert compiled.flags & 2 == 0
+
+
+def test_use_accepts_another_regex_builder_as_the_source():
+    fragment = RegexBuilder().one_or_more().digit()
+    expression = RegexBuilder().string("id=").use(fragment)
+    assert expression.to_regex_string() == "id=\\d+"

--- a/tests/pattern/composition.test.py
+++ b/tests/pattern/composition.test.py
@@ -1,0 +1,40 @@
+"""Tests for the :class:`Pattern` composition surface."""
+
+import pytest
+
+from edify import Pattern, RegexBuilder
+from edify.errors.input import MustBeInstanceError
+
+
+def test_pattern_builds_the_same_element_tree_as_a_builder():
+    pattern = Pattern().between(3, 20).word()
+    builder = RegexBuilder().between(3, 20).word()
+    assert pattern._state == builder._state
+
+
+def test_pattern_has_no_to_regex_terminal():
+    pattern = Pattern().digit()
+    assert not hasattr(pattern, "to_regex")
+
+
+def test_pattern_has_no_to_regex_string_terminal():
+    pattern = Pattern().digit()
+    assert not hasattr(pattern, "to_regex_string")
+
+
+def test_pattern_supports_nested_use_composition():
+    inner = Pattern().one_or_more().digit()
+    outer = Pattern().string("v").use(inner)
+    embedded = RegexBuilder().use(outer)
+    assert embedded.to_regex_string() == "v\\d+"
+
+
+def test_subexpression_still_accepts_a_pattern():
+    pattern = Pattern().at_least(3).word()
+    embedded = RegexBuilder().subexpression(pattern)
+    assert embedded.to_regex_string() == "\\w{3,}"
+
+
+def test_subexpression_rejects_non_builder_input():
+    with pytest.raises(MustBeInstanceError):
+        RegexBuilder().subexpression("not a pattern")


### PR DESCRIPTION
## Summary

Closes #125 — the ``Pattern`` class, a named reusable regex fragment that composes with any builder via ``.subexpression()`` or ``.use()``.
Closes #126 — the ``.use(pattern)`` chain method, the ergonomic alias for the common-case ``.subexpression(pattern)`` (drops flag / anchor overrides, keeps sensible defaults).

## Design

**``Pattern``** is the same fluent surface as ``RegexBuilder`` minus the terminals. It shares every chain-method mixin (anchors, assertions, captures, chain, chars, classes, flags, groups, quantifiers, subexpression). It deliberately does **not** carry ``to_regex`` / ``to_regex_string`` — a pattern is a fragment, and fragments compose upward through ``.use()`` rather than compile themselves. To emit a regex from a pattern, embed it in a builder: ``RegexBuilder().use(my_pattern).to_regex()``.

**``BuilderCore``** (new) holds the immutable-state plumbing that both ``RegexBuilder`` and ``Pattern`` need — the ``_state`` attribute, the ``__init__``, and the clone-and-replace ``_with_state`` helper. Both concrete classes now inherit ``BuilderCore`` instead of duplicating three lines each.

**``.use(pattern)``** lives on ``SubexpressionMixin`` alongside ``.subexpression``. It calls ``self.subexpression(pattern)`` with the common-case defaults, so ``Pattern`` and ``RegexBuilder`` both get it for free. Direct ``.subexpression`` calls remain available when you need the ``namespace`` / ``ignore_flags`` / ``ignore_start_and_end`` overrides.

## Fanout

Closing this unblocks the operator algebra (#122, #123, #124), every validator-to-callable-Pattern migration (#177–#190), the AST walker (#143), and every building-block atom (#172–#176).