### PR TITLE
docs: 1.0 refresh — Python floor, named-backref, license, framing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 Unreleased
 ----------
 
+* **Changed:** Relicensed from Apache-2.0 to `MIT <https://github.com/luciferreeves/edify/blob/main/LICENSE>`_; see the :ref:`license-mit` upgrade note for the patent-grant and pinned-tag caveats.
 * **Breaking:** Dropped support for Python 3.8. Edify now requires Python 3.9 or newer (:pr:`64`). Python 3.8 reached EOL on 2024-10-07; dependencies are now actively dropping it (e.g. ``virtualenv`` 21.5+ requires ``>=3.9``).
 * **Tooling and CI:** Dropped macOS and Windows runners from the CI matrix; Linux-only from here on. Edify is a pure-Python wheel with no platform-specific code, so the multi-OS jobs were buying ~zero signal and produced false negatives. Branch-protection required contexts went from 31 → 13 in lockstep (and now 12 with the Python 3.8 drop) (:pr:`60`).
 * **Dependencies:** Bumped the minimum ``virtualenv`` floor for the CI bootstrap to ``>=21.4.2`` (:pr:`56`, :pr:`58`).

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ It also allows you to verify a string quickly by providing commonly used regex p
 Quick Start
 =============
 
-To get started make sure you have Python 3.9-3.14 installed and then, install Edify from ``pip``:
+To get started make sure you have Python 3.11-3.14 installed and then, install Edify from ``pip``:
 
 .. code-block:: bash
 
@@ -240,7 +240,7 @@ Why Edify?
 
 Regex is a powerful tool, but its syntax is not very intuitive and can be difficult to build, understand, and use. It gets even more difficult when you have to deal with backtracking, look-ahead, and other features that make regex difficult.
 
-That's where Edify becomes extremely useful. It allows you to create regular expressions in a programmatic way by invoking the ``RegexBuilder`` class [#f1]_. The API uses the `fluent builder pattern <https://en.wikipedia.org/wiki/Fluent_interface>`_, and is completely immutable. It is built to be discoverable and predictable.
+That's where Edify becomes extremely useful. It allows you to create regular expressions in a programmatic way by invoking the ``RegexBuilder`` class. The API uses the `fluent builder pattern <https://en.wikipedia.org/wiki/Fluent_interface>`_, and is completely immutable. It is built to be discoverable and predictable.
 
 - Properties and methods describe what they do in plain English.
 - Order matters! Quantifiers are specified before the thing they change, just like in English (e.g. ``RegexBuilder().exactly(5).digit()``).
@@ -250,10 +250,6 @@ That's where Edify becomes extremely useful. It allows you to create regular exp
 Edify turns those complex and unwieldy regexes that appear in code reviews into something that can be read, understood, and **properly reviewed** by your peers - and maintained by anyone!
 
 
-.. _SuperExpressive: https://github.com/francisrstokes/super-expressive
-
-.. [1]:
-
 License & Contributing
 ======================
 
@@ -262,8 +258,3 @@ This project is licensed under the `MIT License <https://github.com/luciferreeve
 Contributors
 ------------
 .. image:: https://contrib.rocks/image?repo=luciferreeves/edify
-
-
-.. rubric:: Footnotes
-
-.. [#f1] ``RegexBuilder`` class based on the `SuperExpressive`_ library.

--- a/docs/regex-builder/builder/index.rst
+++ b/docs/regex-builder/builder/index.rst
@@ -1,7 +1,7 @@
 RegexBuilder
 ============
 
-RegexBuilder is a class that helps you build regular expressions. It is based on the `SuperExpressive <https://github.com/francisrstokes/super-expressive>`_ library. The API uses the `fluent builder pattern <https://en.wikipedia.org/wiki/Fluent_interface>`_, and is completely immutable. It is built to be discoverable and predictable.
+RegexBuilder is a class that helps you build regular expressions with a fluent, immutable Python API. The API uses the `fluent builder pattern <https://en.wikipedia.org/wiki/Fluent_interface>`_, and is completely immutable. It is built to be discoverable and predictable.
 
 - Properties and methods describe what they do in plain English.
 - Order matters! Quantifiers are specified before the thing they change, just like in English (e.g. ``RegexBuilder().exactly(5).digit()``.)
@@ -310,17 +310,13 @@ RegexBuilder is a class that helps you build regular expressions. It is based on
 .named_back_reference(name)
 ---------------------------
 
-``.named_back_reference()`` matches exactly what was previously matched by a :ref:`named_capture`.
-
-.. warning::
-
-    Python does not support named back references. If you try to call the ``to_regex()`` method on a named back reference, it will raise an exception. For, those reasons, ``to_regex_string()`` is provided instead. It returns a string that can be used to create a regular expression. You can try using the regular expression directly with another library like `regex <https://pypi.python.org/pypi/regex>`_.
+``.named_back_reference()`` matches exactly what was previously matched by a :ref:`named_capture`. Emits Python's native ``(?P=name)`` syntax, so ``to_regex()`` compiles and matches directly against the standard-library ``re`` module.
 
 .. code-block:: python
 
     from edify import RegexBuilder
 
-    # returns /(?<interestingStuff>[a-f][0-9]hello)something else\k<interestingStuff>/
+    # compiles to '(?P<interestingStuff>[a-f][0-9]hello)something else(?P=interestingStuff)'
     expr = (
         RegexBuilder()
         .named_capture('interestingStuff')
@@ -330,8 +326,9 @@ RegexBuilder is a class that helps you build regular expressions. It is based on
         .end()
         .string('something else')
         .named_back_reference('interestingStuff')
-        .to_regex_string()
+        .to_regex()
     )
+    assert expr.search('a9hellosomething elsea9hello')
 
 .. _backreference:
 

--- a/docs/upgrading/0.3-to-1.0.rst
+++ b/docs/upgrading/0.3-to-1.0.rst
@@ -63,3 +63,24 @@ Several 0.3 names have been merged into more general patterns in 1.0:
 The new names accept any recognised form of their concept, and the old
 name-plus-``form`` variants continue to work via each validator's
 ``form`` / ``strict`` / ``version`` keyword arguments where applicable.
+
+.. _license-mit:
+
+License change: Apache-2.0 to MIT
+---------------------------------
+
+Starting with the 1.0 release, edify is distributed under the `MIT License
+<https://github.com/luciferreeves/edify/blob/main/LICENSE>`_ instead of
+Apache-2.0. Two facts users need to know:
+
+- **No more explicit patent grant.** Apache-2.0 carried an explicit patent
+  grant from every contributor to every user. The MIT License does not.
+  If your compliance policy specifically relies on that patent grant,
+  pin ``edify<1.0``; every 0.3.x wheel on PyPI remains Apache-2.0
+  permanently.
+- **Older tags stay Apache-2.0 forever.** Every git tag ``v0.3.0`` and
+  earlier — and every wheel built from those tags — remains licensed under
+  Apache-2.0. Pinned installs are unaffected; only the ``1.0.0`` tag and
+  later ship under MIT.
+
+No API changes accompany the relicense.


### PR DESCRIPTION
Cleans up the docs that still reflect pre-1.0 realities.

## Changes

- **README Python version** — quick-start now reads Python 3.11-3.14 (was 3.9-3.14). Reflects the post-3.8-drop floor.
- **RegexBuilder named-backref docs** — the stale warning that ``.to_regex()`` raises on ``.named_back_reference()`` is gone. The chain emits Python's native ``(?P=name)`` syntax; ``to_regex()`` compiles and matches directly. Example rewritten around the working chain.
- **Drop SuperExpressive framing** — the derivative-of framing (README footnote + hyperlink target + first sentence of ``docs/regex-builder/builder/index.rst``) is removed. Edify stands on its own now.
- **UPGRADING license note** — new ``license-mit`` anchor under ``docs/upgrading/0.3-to-1.0.rst`` covering the two user-facing facts about the relicense: no more explicit patent grant, and all ``v0.3.0``-and-earlier tags stay Apache-2.0 forever.
- **CHANGELOG relicense entry** — ``Changed`` bullet on the Unreleased section cross-linking the LICENSE file and the new ``:ref:`license-mit``` anchor.

Closes #229
Closes #230
Closes #235
Closes #236
Closes #252