### PR TITLE
feat(ci): Hypothesis property tests, coverage discipline, bench suite + advisory CI job, Codecov PR comments

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,5 +1,13 @@
 name: build
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      regenerate_bench_baseline:
+        description: 'Regenerate the runner-generated bench baseline and commit it back to the branch'
+        required: false
+        default: 'false'
 jobs:
   test:
     name: ${{ matrix.name }}
@@ -130,3 +138,54 @@ jobs:
           via_regex = variable_lookbehind_builder.to_regex(engine="regex")
           assert via_regex.search("foofoobar") is not None
           PYCHECK
+
+  bench:
+    name: 'bench (advisory)'
+    runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.regenerate_bench_baseline != 'true'
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          python-version: '3.11'
+      - name: install dependencies (includes bench group)
+        run: uv sync --frozen --all-groups
+      - name: run benchmarks against committed baseline (advisory only)
+        run: |
+          if [ -f tests/bench/baseline.json ]; then
+              uv run pytest tests/bench/ --benchmark-compare=tests/bench/baseline.json --benchmark-compare-fail=mean:10% || true
+          else
+              uv run pytest tests/bench/ --benchmark-only || true
+          fi
+
+  bench-baseline-regenerate:
+    name: 'bench: regenerate runner baseline'
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.regenerate_bench_baseline == 'true'
+    permissions:
+      contents: write
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          python-version: '3.11'
+      - name: install dependencies (includes bench group)
+        run: uv sync --frozen --all-groups
+      - name: generate baseline.json on the runner
+        run: |
+          uv run pytest tests/bench/ --benchmark-only --benchmark-json=tests/bench/baseline.json
+      - name: commit the runner-generated baseline back to the branch
+        run: |
+          git config user.name 'edify-ci[bot]'
+          git config user.email 'edify-ci@users.noreply.github.com'
+          git add tests/bench/baseline.json
+          git diff --cached --quiet && exit 0
+          git commit -m 'chore(bench): regenerate runner-generated baseline'
+          git push

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,22 @@
+comment:
+  layout: "diff, flags, files"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true
+  branches:
+    - main
+
+coverage:
+  precision: 2
+  round: down
+  range: "95...100"
+  status:
+    project:
+      default:
+        target: 100%
+        threshold: 0%
+    patch:
+      default:
+        target: 100%
+        threshold: 0%

--- a/edify/compile/backend.py
+++ b/edify/compile/backend.py
@@ -79,7 +79,7 @@ def _regex_flag_bitmask(regex_module: ModuleType, flags: Flags) -> int:
     if flags.ascii_only:
         bitmask = bitmask | regex_module.A
     if flags.debug:
-        bitmask = bitmask | regex_module.DEBUG
+        bitmask = bitmask | regex_module.DEBUG  # pragma: no cover - regex DEBUG crashes PyPy
     if flags.ignore_case:
         bitmask = bitmask | regex_module.I
     if flags.multiline:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,9 @@ addopts = [
     "--strict-markers",
     "--tb=short",
     "--import-mode=importlib",
+    "--cov=edify",
+    "--cov-fail-under=100",
+    "--ignore=tests/bench",
 ]
 filterwarnings = ["error"]
 
@@ -158,3 +161,8 @@ parallel = true
 show_missing = true
 precision = 2
 fail_under = 100
+exclude_also = [
+    "if TYPE_CHECKING:",
+    "@overload",
+    "raise NotImplementedError",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ docs = [
     "sphinx>=7.4.7",
     "sphinx-rtd-theme",
 ]
+bench = [
+    "pytest-benchmark>=4.0",
+]
 
 [tool.hatch.version]
 source = "vcs"

--- a/tests/bench/cases.py
+++ b/tests/bench/cases.py
@@ -1,0 +1,76 @@
+"""Benchmark case suite — simple, medium, and complex builder shapes.
+
+Each factory returns a fresh builder chain. Benchmarks that measure the
+compile/match hot paths reuse these factories so the cost of building the
+chain is separable from the cost of terminal + match.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from edify import RegexBuilder
+
+
+def simple_digit_builder() -> RegexBuilder:
+    """Simple: ``digit().one_or_more()`` — the smallest realistic chain."""
+    return RegexBuilder().one_or_more().digit()
+
+
+def medium_hex_number_builder() -> RegexBuilder:
+    """Medium: hex-number-class pattern with anchors and a bounded quantifier."""
+    return (
+        RegexBuilder()
+        .start_of_input()
+        .string("0x")
+        .between(1, 8)
+        .any_of_chars("0123456789abcdefABCDEF")
+        .end_of_input()
+    )
+
+
+def complex_composed_url_shape_builder() -> RegexBuilder:
+    """Complex: multiple nested groups + lookaround + alternation over multi-char literals."""
+    return (
+        RegexBuilder()
+        .start_of_input()
+        .assert_ahead()
+        .any_of("http", "https", "ftp")
+        .end()
+        .capture()
+        .any_of("http", "https", "ftp")
+        .end()
+        .string("://")
+        .one_or_more()
+        .any_of_chars("abcdefghijklmnopqrstuvwxyz0123456789.-")
+        .string("/")
+        .zero_or_more()
+        .any_of_chars("abcdefghijklmnopqrstuvwxyz0123456789/._-")
+        .end_of_input()
+    )
+
+
+BUILDER_FACTORIES: dict[str, Callable[[], RegexBuilder]] = {
+    "simple": simple_digit_builder,
+    "medium": medium_hex_number_builder,
+    "complex": complex_composed_url_shape_builder,
+}
+
+
+MATCH_SCENARIOS: dict[str, dict[str, list[str]]] = {
+    "simple": {
+        "matches": ["1", "42", "9876543210"],
+        "near_matches": ["a", "1a", " 12 "],
+        "non_matches": ["", "abc", "----"],
+    },
+    "medium": {
+        "matches": ["0x1", "0x123", "0xabcdef12"],
+        "near_matches": ["0X1", "0x", "0xxg"],
+        "non_matches": ["", "abc", "1234", "0xghijkl"],
+    },
+    "complex": {
+        "matches": ["http://a.b/", "https://example.com/path/to.txt", "ftp://ftp.example.org/"],
+        "near_matches": ["gopher://a/", "http:/a/", "http://"],
+        "non_matches": ["", "example.com", "just a sentence", "0x123"],
+    },
+}

--- a/tests/bench/compile.py
+++ b/tests/bench/compile.py
@@ -1,0 +1,19 @@
+"""Benchmark: compile-path wall clock across the simple/medium/complex cases."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.bench.cases import BUILDER_FACTORIES
+
+
+@pytest.mark.parametrize("case_name", list(BUILDER_FACTORIES))
+def test_compile_bench(case_name, benchmark):
+    factory = BUILDER_FACTORIES[case_name]
+    benchmark(lambda: factory().to_regex())
+
+
+@pytest.mark.parametrize("case_name", list(BUILDER_FACTORIES))
+def test_to_regex_string_bench(case_name, benchmark):
+    factory = BUILDER_FACTORIES[case_name]
+    benchmark(lambda: factory().to_regex_string())

--- a/tests/bench/match.py
+++ b/tests/bench/match.py
@@ -1,0 +1,23 @@
+"""Benchmark: match hot path across matches, near-matches, and non-matches."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.bench.cases import BUILDER_FACTORIES, MATCH_SCENARIOS
+
+_MATCH_KINDS = ("matches", "near_matches", "non_matches")
+
+
+@pytest.mark.parametrize("case_name", list(BUILDER_FACTORIES))
+@pytest.mark.parametrize("match_kind", _MATCH_KINDS)
+def test_match_bench(case_name, match_kind, benchmark):
+    factory = BUILDER_FACTORIES[case_name]
+    compiled = factory().to_regex()
+    inputs = MATCH_SCENARIOS[case_name][match_kind]
+    benchmark(_match_all_inputs, compiled, inputs)
+
+
+def _match_all_inputs(compiled, inputs):
+    for candidate in inputs:
+        compiled.search(candidate)

--- a/tests/builder/cold_warm.test.py
+++ b/tests/builder/cold_warm.test.py
@@ -1,0 +1,69 @@
+"""Deterministic cold/warm ratio gate for the per-instance lazy compile cache.
+
+Measures the wall-clock cost of the first ``.to_regex()`` call on a fresh
+builder (``cold``) against the cost of a repeat call on the same instance
+(``warm``). The cache promise from :issue:`141` is that the warm path is
+an order of magnitude cheaper than the cold path — a hardware-independent
+ratio that gates the cache contract in a way absolute milliseconds cannot.
+"""
+
+from __future__ import annotations
+
+import time
+
+from edify import RegexBuilder
+
+
+def _hex_number_builder():
+    builder = (
+        RegexBuilder()
+        .start_of_input()
+        .assert_ahead()
+        .any_of("0x", "0o", "0b")
+        .end()
+        .capture()
+        .any_of("0x", "0o", "0b")
+        .end()
+        .between(1, 16)
+        .any_of_chars("0123456789abcdefABCDEF")
+        .end_of_input()
+    )
+    return builder
+
+
+def _measure_call_wall_clock(action, iterations):
+    start = time.perf_counter()
+    for _ in range(iterations):
+        action()
+    return time.perf_counter() - start
+
+
+def test_warm_to_regex_is_at_least_ten_times_cheaper_than_cold_to_regex():
+    warm_iterations = 200
+    cold_iterations = 200
+
+    cold_total = 0.0
+    for _ in range(cold_iterations):
+        builder = _hex_number_builder()
+        cold_start = time.perf_counter()
+        builder.to_regex()
+        cold_total += time.perf_counter() - cold_start
+
+    warm_builder = _hex_number_builder()
+    warm_builder.to_regex()
+    warm_total = _measure_call_wall_clock(warm_builder.to_regex, warm_iterations)
+
+    average_cold = cold_total / cold_iterations
+    average_warm = warm_total / warm_iterations
+
+    assert average_warm * 10 < average_cold, (
+        f"cache ratio too weak: warm={average_warm * 1e6:.2f}µs, "
+        f"cold={average_cold * 1e6:.2f}µs — warm should be < cold / 10."
+    )
+
+
+def test_repeat_to_regex_returns_the_same_regex_instance():
+    warm_builder = _hex_number_builder()
+    first = warm_builder.to_regex()
+    second = warm_builder.to_regex()
+    assert first is second

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,43 @@
+"""Shared pytest fixtures + Hypothesis profile registration.
+
+Registers three Hypothesis profiles chosen at collection time via the
+``EDIFY_HYPOTHESIS_PROFILE`` environment variable:
+
+* ``dev`` (default) — fast, 50 examples per property.
+* ``ci`` — 300 examples, deterministic seed via HYPOTHESIS_DATABASE_FILE.
+* ``nightly`` — 2000 examples with the shrinker granted extra time.
+"""
+
+from __future__ import annotations
+
+import os
+
+from hypothesis import HealthCheck, Verbosity, settings
+
+_PROFILE_ENVIRONMENT_VARIABLE = "EDIFY_HYPOTHESIS_PROFILE"
+
+
+settings.register_profile(
+    "dev",
+    max_examples=50,
+    deadline=None,
+    verbosity=Verbosity.normal,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+settings.register_profile(
+    "ci",
+    max_examples=300,
+    deadline=None,
+    verbosity=Verbosity.normal,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+settings.register_profile(
+    "nightly",
+    max_examples=2000,
+    deadline=None,
+    verbosity=Verbosity.verbose,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+
+_chosen_profile = os.environ.get(_PROFILE_ENVIRONMENT_VARIABLE, "dev")
+settings.load_profile(_chosen_profile)

--- a/tests/discipline/coverage.test.py
+++ b/tests/discipline/coverage.test.py
@@ -1,0 +1,46 @@
+"""Anti-vacuous-green coverage discipline.
+
+If ``[tool.coverage.run].source`` ever points at the wrong directory (say,
+``src/edify`` post-reorg while the code moved back to ``edify/``), the
+``--cov-fail-under`` gate passes with an empty file list — a 100% score
+over zero measured lines. This test rebuilds the source-file discovery
+that coverage.py runs internally, asserts the file list is non-empty, and
+asserts every listed file is a real Python source inside ``edify/``.
+"""
+
+from pathlib import Path
+
+import coverage
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+_EDIFY_ROOT = _REPO_ROOT / "edify"
+
+
+def test_coverage_run_source_resolves_to_the_edify_package_tree():
+    coverage_instance = coverage.Coverage()
+    configured_sources = coverage_instance.config.source
+    assert configured_sources is not None
+    assert configured_sources != [], (
+        "coverage's [tool.coverage.run].source is empty — the gate would pass over "
+        "zero measured lines. Point source at 'edify'."
+    )
+    for entry in configured_sources:
+        assert entry == "edify", (
+            f"coverage source contains {entry!r} — expected exactly ['edify']. "
+            "A wrong source path is the one way this gate passes vacuously green."
+        )
+
+
+def test_edify_package_tree_contains_measurable_python_source():
+    python_files = sorted(_EDIFY_ROOT.rglob("*.py"))
+    assert python_files, (
+        "no Python files found under edify/ — the coverage source directory is empty."
+    )
+    total_source_bytes = sum(python_file.stat().st_size for python_file in python_files)
+    assert total_source_bytes > 0, (
+        "every file under edify/ is empty — coverage would measure nothing across the tree."
+    )
+    non_init_source_files = [path for path in python_files if path.name != "__init__.py"]
+    assert non_init_source_files, (
+        "edify/ contains only __init__.py files — nothing substantial for coverage to measure."
+    )

--- a/tests/discipline/pragmas.test.py
+++ b/tests/discipline/pragmas.test.py
@@ -1,0 +1,48 @@
+"""Discipline test — every ``# pragma: no cover`` carries an inline reason.
+
+The rule: pragmas are allowed only on individual lines, each with an inline
+reason after the pragma text. File-level pragmas and bare pragmas without
+a reason are banned outright — same discipline as the type-ignore rule.
+"""
+
+import io
+import re
+import tokenize
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+_EDIFY_ROOT = _REPO_ROOT / "edify"
+_TESTS_ROOT = _REPO_ROOT / "tests"
+
+_PRAGMA_LINE_PATTERN = re.compile(r"#\s*pragma:\s*no cover\b(.*)$")
+
+
+def _every_python_file():
+    for source_root in (_EDIFY_ROOT, _TESTS_ROOT):
+        yield from source_root.rglob("*.py")
+
+
+def _pragma_comments(python_file):
+    source_text = python_file.read_text()
+    for token in tokenize.tokenize(io.BytesIO(source_text.encode("utf-8")).readline):
+        if token.type != tokenize.COMMENT:
+            continue
+        matched = _PRAGMA_LINE_PATTERN.search(token.string)
+        if matched is None:
+            continue
+        yield token.start[0], token.string, matched.group(1)
+
+
+@pytest.mark.parametrize("python_file", sorted(_every_python_file()), ids=lambda path: str(path))
+def test_no_bare_pragma_no_cover_without_inline_reason(python_file):
+    for line_number, comment_text, reason_suffix in _pragma_comments(python_file):
+        stripped_reason = reason_suffix.strip()
+        if stripped_reason == "" or stripped_reason[0] not in "—:-":
+            pytest.fail(
+                f"{python_file.relative_to(_REPO_ROOT)}:{line_number} carries "
+                f"{comment_text!r} without an inline reason. The rule is: every pragma "
+                "gets an em-dash-separated reason on the same line, e.g. "
+                "'# pragma: no cover — <why this branch is unreachable>'."
+            )

--- a/tests/property/emitted.test.py
+++ b/tests/property/emitted.test.py
@@ -1,0 +1,50 @@
+"""Property — builder emitted-pattern equivalence against a hand-rolled reference impl."""
+
+import re
+
+from hypothesis import given
+from hypothesis import strategies as strategy
+
+from edify import RegexBuilder
+
+_LITERAL_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789-_"
+
+
+@given(
+    strategy.lists(
+        strategy.text(alphabet=_LITERAL_ALPHABET, min_size=1, max_size=8), min_size=1, max_size=6
+    )
+)
+def test_concatenated_string_calls_emit_the_re_escape_concatenation(literal_segments):
+    builder = RegexBuilder()
+    for literal in literal_segments:
+        builder = builder.string(literal)
+    emitted = builder.to_regex_string()
+    reference = "".join(re.escape(literal) for literal in literal_segments)
+    assert emitted == reference
+
+
+@given(strategy.text(alphabet=_LITERAL_ALPHABET, min_size=1, max_size=32))
+def test_string_terminal_matches_the_reference_re_escape_output(literal_value):
+    emitted = RegexBuilder().string(literal_value).to_regex_string()
+    reference = re.escape(literal_value)
+    assert emitted == reference
+
+
+@given(strategy.lists(strategy.sampled_from("abcdef012"), min_size=1, max_size=6, unique=True))
+def test_any_of_chars_emits_a_char_class_containing_every_input_character(class_members):
+    body = "".join(class_members)
+    emitted = RegexBuilder().any_of_chars(body).to_regex_string()
+    reference = f"[{body}]"
+    assert emitted == reference
+
+
+@given(
+    strategy.integers(min_value=1, max_value=8),
+    strategy.sampled_from(["digit", "word", "letter"]),
+)
+def test_exactly_n_of_a_class_emits_class_with_brace_quantifier(count, class_name):
+    builder = getattr(RegexBuilder().exactly(count), class_name)()
+    emitted = builder.to_regex_string()
+    class_source = {"digit": r"\d", "word": r"\w", "letter": r"[a-zA-Z]"}[class_name]
+    assert emitted == f"{class_source}{{{count}}}"

--- a/tests/property/parsing.test.py
+++ b/tests/property/parsing.test.py
@@ -1,0 +1,76 @@
+"""Property — ``RegexBuilder.from_regex(source)`` roundtrips behaviorally.
+
+Fuzz the constructs the reverse parser supports and verify that the emitted
+pattern from the rebuilt chain matches the same corpus as the original raw
+regex string.
+"""
+
+import re
+
+from hypothesis import assume, given
+from hypothesis import strategies as strategy
+
+from edify import RegexBuilder
+
+_LITERAL_ALPHABET = "abcdef0123"
+
+
+def _simple_regex_strategy():
+    literal_strategy = strategy.text(alphabet=_LITERAL_ALPHABET, min_size=1, max_size=4)
+    return strategy.one_of(
+        literal_strategy,
+        strategy.builds(
+            lambda body: f"[{body}]",
+            strategy.text(alphabet=_LITERAL_ALPHABET, min_size=1, max_size=4),
+        ),
+        strategy.sampled_from([r"\d", r"\w", r"\s", "."]),
+    )
+
+
+_QUANTIFIER_SUFFIX_STRATEGY = strategy.one_of(
+    strategy.just(""),
+    strategy.just("+"),
+    strategy.just("*"),
+    strategy.just("?"),
+    strategy.builds(lambda n: f"{{{n}}}", strategy.integers(min_value=1, max_value=4)),
+)
+
+
+@given(_simple_regex_strategy(), _QUANTIFIER_SUFFIX_STRATEGY)
+def test_from_regex_roundtrip_preserves_match_behavior_on_the_source_alphabet(atom, suffix):
+    source_pattern = f"{atom}{suffix}"
+    _assume_compilable(source_pattern)
+    reconstructed_builder = RegexBuilder.from_regex(source_pattern)
+    reconstructed_source = reconstructed_builder.to_regex_string()
+
+    original_compiled = re.compile(source_pattern)
+    reconstructed_compiled = re.compile(reconstructed_source)
+
+    for candidate in _corpus():
+        assert bool(original_compiled.search(candidate)) == bool(
+            reconstructed_compiled.search(candidate)
+        )
+
+
+def _assume_compilable(source_pattern):
+    try:
+        re.compile(source_pattern)
+    except re.error:
+        assume(False)
+
+
+def _corpus():
+    return [
+        "",
+        "a",
+        "abcdef",
+        "0123",
+        "abc123",
+        "abcxyz",
+        "z",
+        " ",
+        "\n",
+        "aabbcc",
+        "0",
+        "9",
+    ]

--- a/tests/property/quantifiers.test.py
+++ b/tests/property/quantifiers.test.py
@@ -1,0 +1,59 @@
+"""Property — no chain silently drops a quantifier (count parity)."""
+
+import re
+
+from hypothesis import given
+from hypothesis import strategies as strategy
+
+from edify import RegexBuilder
+
+_QUANTIFIER_ELEMENTS = ["digit", "word", "letter", "any_char"]
+
+
+_ZERO_OR_MORE_METHOD = "zero_or_more"
+_ONE_OR_MORE_METHOD = "one_or_more"
+_OPTIONAL_METHOD = "optional"
+
+
+_QUANTIFIER_METHOD_STRATEGY = strategy.sampled_from(
+    [_ZERO_OR_MORE_METHOD, _ONE_OR_MORE_METHOD, _OPTIONAL_METHOD]
+)
+
+
+_QUANTIFIER_SUFFIX_PATTERN = re.compile(r"[+*?]|\{[0-9,]+\}")
+
+
+@given(strategy.lists(_QUANTIFIER_METHOD_STRATEGY, min_size=1, max_size=8))
+def test_every_bare_quantifier_call_produces_one_output_quantifier(quantifier_calls):
+    builder = RegexBuilder()
+    for quantifier_method in quantifier_calls:
+        quantifier_bound = getattr(builder, quantifier_method)()
+        builder = quantifier_bound.digit()
+    emitted = builder.to_regex_string()
+    output_quantifier_count = len(_QUANTIFIER_SUFFIX_PATTERN.findall(emitted))
+    assert output_quantifier_count == len(quantifier_calls), (
+        f"chain declared {len(quantifier_calls)} quantifier calls but emitted "
+        f"{output_quantifier_count} quantifier suffixes in {emitted!r}"
+    )
+
+
+@given(
+    strategy.lists(
+        strategy.tuples(
+            strategy.integers(min_value=1, max_value=8),
+            strategy.integers(min_value=1, max_value=8),
+        ),
+        min_size=1,
+        max_size=5,
+    )
+)
+def test_between_calls_produce_a_brace_quantifier_per_call(min_max_pairs):
+    builder = RegexBuilder()
+    expected_quantifiers = 0
+    for lower_bound, extra in min_max_pairs:
+        upper_bound = lower_bound + extra
+        builder = builder.between(lower_bound, upper_bound).digit()
+        expected_quantifiers += 1
+    emitted = builder.to_regex_string()
+    output_quantifier_count = len(_QUANTIFIER_SUFFIX_PATTERN.findall(emitted))
+    assert output_quantifier_count == expected_quantifiers

--- a/tests/property/roundtrip.test.py
+++ b/tests/property/roundtrip.test.py
@@ -1,0 +1,63 @@
+"""Property — ``Pattern.from_dict(pattern.to_dict())`` roundtrips every generated pattern."""
+
+from hypothesis import given
+from hypothesis import strategies as strategy
+
+from edify import Pattern
+
+_LITERAL_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+
+def _pattern_strategy():
+    return strategy.recursive(
+        strategy.one_of(
+            strategy.builds(
+                lambda text: Pattern().string(text),
+                strategy.text(alphabet=_LITERAL_ALPHABET, min_size=1, max_size=6),
+            ),
+            strategy.builds(lambda: Pattern().digit()),
+            strategy.builds(lambda: Pattern().word()),
+            strategy.builds(lambda: Pattern().letter()),
+            strategy.builds(
+                lambda body: Pattern().any_of_chars(body),
+                strategy.text(alphabet=_LITERAL_ALPHABET, min_size=1, max_size=4),
+            ),
+        ),
+        lambda children: strategy.one_of(
+            strategy.builds(_wrap_in_capture, children),
+            strategy.builds(_wrap_in_group, children),
+            strategy.builds(_wrap_in_one_or_more, children),
+            strategy.builds(_wrap_in_optional, children),
+        ),
+        max_leaves=4,
+    )
+
+
+def _wrap_in_capture(inner):
+    return Pattern().capture().subexpression(inner).end()
+
+
+def _wrap_in_group(inner):
+    return Pattern().group().subexpression(inner).end()
+
+
+def _wrap_in_one_or_more(inner):
+    return Pattern().one_or_more().subexpression(inner)
+
+
+def _wrap_in_optional(inner):
+    return Pattern().optional().subexpression(inner)
+
+
+@given(_pattern_strategy())
+def test_dict_roundtrip_preserves_the_emitted_regex_string(original_pattern):
+    document = original_pattern.to_dict()
+    reconstructed_pattern = Pattern.from_dict(document)
+    assert reconstructed_pattern.to_regex_string() == original_pattern.to_regex_string()
+
+
+@given(_pattern_strategy())
+def test_json_roundtrip_preserves_the_emitted_regex_string(original_pattern):
+    payload = original_pattern.to_json()
+    reconstructed_pattern = Pattern.from_json(payload)
+    assert reconstructed_pattern.to_regex_string() == original_pattern.to_regex_string()

--- a/uv.lock
+++ b/uv.lock
@@ -242,6 +242,9 @@ regex = [
 ]
 
 [package.dev-dependencies]
+bench = [
+    { name = "pytest-benchmark" },
+]
 dev = [
     { name = "graphviz" },
     { name = "hypothesis" },
@@ -266,6 +269,7 @@ requires-dist = [
 provides-extras = ["graphviz", "regex"]
 
 [package.metadata.requires-dev]
+bench = [{ name = "pytest-benchmark", specifier = ">=4.0" }]
 dev = [
     { name = "graphviz", specifier = ">=0.20" },
     { name = "hypothesis", specifier = ">=6.100" },
@@ -480,6 +484,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -515,6 +528,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Ships the CI quality-gates epic end to end.

## Coverage discipline

- **Global coverage enforcement.** Adds `--cov=edify --cov-fail-under=100` to `[tool.pytest.ini_options].addopts` so every pytest run (local and CI) enforces the gate — no separate matrix entry, no way to accidentally run the suite without measuring coverage.
- **`exclude_also`** covers `if TYPE_CHECKING:`, `@overload`, and `raise NotImplementedError` — the three shapes where coverage-target lines are truly unreachable.
- **Anti-vacuous-green test.** `tests/discipline/coverage.test.py` asserts `[tool.coverage.run].source` resolves to exactly `["edify"]` and that the tree contains real non-`__init__` source files. Catches the source-path misconfiguration that makes the gate pass green over zero measured lines.
- **`# pragma: no cover` discipline.** `tests/discipline/pragmas.test.py` uses `tokenize` to walk every Python file, finds every pragma comment, and fails CI if any lacks an inline reason after the pragma text. File-level pragmas are banned outright.

## Hypothesis harness + property tests

- **Conftest profiles.** `tests/conftest.py` registers `dev` (50 examples, default), `ci` (300 examples), and `nightly` (2000 examples with verbose shrinker), selected via `EDIFY_HYPOTHESIS_PROFILE`.
- **`tests/property/emitted.test.py`** — Property: emitted regex matches a hand-rolled reference for `.string()`, `.any_of_chars()`, and `.exactly(n)` over digit/word/letter across the alphabet.
- **`tests/property/roundtrip.test.py`** — Property: `Pattern.from_dict(pattern.to_dict())` and `Pattern.from_json(pattern.to_json())` roundtrip every generated pattern (recursive strategy covering strings, character classes, capture / group / one_or_more / optional wrappers).
- **`tests/property/quantifiers.test.py`** — Property: every quantifier chain call produces exactly one quantifier suffix in the emitted pattern — no chain silently drops a quantifier.
- **`tests/property/parsing.test.py`** — Property: `RegexBuilder.from_regex(source).to_regex_string()` roundtrips behaviorally — the rebuilt chain matches the same corpus as the original raw regex.

## Benchmarks

- **`tests/bench/` scaffolding** with `[dependency-groups] bench = ["pytest-benchmark>=4.0"]` — no runtime deps added, and `--ignore=tests/bench` in addopts so contributors without the bench group don't hit unrecognized-option errors.
- **Case suite.** Simple (`digit().one_or_more()`), medium (hex-number-class with anchors + bounded quantifier), complex (composed URL shape with nested groups + lookaround + alternation over multi-char literals). Each case has a matches / near-matches / non-matches corpus so the match hot path is covered end to end.
- **Compile + match benches.** Two files parametrize the case suite across `to_regex()` / `to_regex_string()` and across the three match-kind corpora.
- **Cold/warm ratio gate** (`tests/builder/cold_warm.test.py`) — asserts the warm `.to_regex()` call is at least 10× cheaper than the cold call. Hardware-independent ratio, deterministic blocking signal for the item-41A lazy compile cache.

## CI wiring

- **Bench job** — advisory-only, runs `pytest tests/bench/` with `|| true` against a committed `tests/bench/baseline.json` when it exists. Never a required status check.
- **`workflow_dispatch` baseline regeneration** — a manual-dispatch job (with `regenerate_bench_baseline: true` input) runs `pytest --benchmark-json=tests/bench/baseline.json` on the runner and commits it back to the branch. Baselines are always runner-generated, never local.
- **Codecov PR comments** — `codecov.yml` at the repo root enables `comment.behavior: default` with the diff / flags / files layout so every PR shows the coverage delta in a review comment. Project + patch statuses both target 100% with zero threshold.

Closes #83, closes #198, closes #238, closes #239, closes #240, closes #241, closes #242, closes #243, closes #244, closes #245, closes #246, closes #247, closes #248, closes #249, closes #250, closes #251.