### PR TITLE
Move the public-surface migration gate to its own pull_request workflow

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -63,41 +63,6 @@ jobs:
       - name: ${{ matrix.name }}
         run: ${{ matrix.command }}
 
-  surface-migration-gate:
-    name: 'public-surface migration gate'
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-        with:
-          fetch-depth: 0
-      - name: require a changes/ fragment when the public surface moves
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          if echo "$PR_TITLE" | grep -q '\[no-migration\]'; then
-              echo "PR marked [no-migration]; skipping the fragment requirement."
-              exit 0
-          fi
-          if ! git cat-file -e "$BASE_SHA:.public-surface" 2>/dev/null; then
-              echo ".public-surface is introduced on this branch; no prior surface to migrate from."
-              exit 0
-          fi
-          if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- .public-surface; then
-              echo "Public surface unchanged; no fragment required."
-              exit 0
-          fi
-          added_fragments=$(git diff --name-only --diff-filter=A "$BASE_SHA" "$HEAD_SHA" -- 'changes/*.rst' | grep -v 'changes/README.rst' || true)
-          if [ -z "$added_fragments" ]; then
-              echo "::error::.public-surface changed but no changes/ fragment was added. Add a fragment describing the migration, or mark the PR title with [no-migration]."
-              exit 1
-          fi
-          echo "Public surface changed and a changes/ fragment accompanies it:"
-          echo "$added_fragments"
-
   install-without-regex-extra:
     name: 'install: edify (no [regex] extra)'
     runs-on: ubuntu-latest

--- a/.github/workflows/surface-migration-gate.yml
+++ b/.github/workflows/surface-migration-gate.yml
@@ -1,0 +1,36 @@
+name: public-surface migration gate
+on: pull_request
+jobs:
+  surface-migration-gate:
+    name: 'public-surface migration gate'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
+      - name: require a changes/ fragment when the public surface moves
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if echo "$PR_TITLE" | grep -q '\[no-migration\]'; then
+              echo "PR marked [no-migration]; skipping the fragment requirement."
+              exit 0
+          fi
+          if ! git cat-file -e "$BASE_SHA:.public-surface" 2>/dev/null; then
+              echo ".public-surface is introduced on this branch; no prior surface to migrate from."
+              exit 0
+          fi
+          if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- .public-surface; then
+              echo "Public surface unchanged; no fragment required."
+              exit 0
+          fi
+          added_fragments=$(git diff --name-only --diff-filter=A "$BASE_SHA" "$HEAD_SHA" -- 'changes/*.rst' | grep -v 'changes/README.rst' || true)
+          if [ -z "$added_fragments" ]; then
+              echo "::error::.public-surface changed but no changes/ fragment was added. Add a fragment describing the migration, or mark the PR title with [no-migration]."
+              exit 1
+          fi
+          echo "Public surface changed and a changes/ fragment accompanies it:"
+          echo "$added_fragments"


### PR DESCRIPTION
The public-surface migration gate needs a pull request's base/head SHAs, so it can't run on a plain push — it evaluates its `if` to false and shows up as a **skipped** check on every push, main included. This moves it out of the shared `[push, pull_request]` workflow into its own `on: pull_request` workflow, so on push runs the job simply doesn't exist and no skipped check appears.

On pull requests it runs exactly as before: the bootstrap exemption (skip when `.public-surface` is first introduced) and the `[no-migration]` title escape hatch are both intact.
