### PR TITLE
ci: gate the docs build on its own warnings and let linkcheck report without blocking

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -27,7 +27,11 @@ jobs:
             os: 'ubuntu-latest'
           - name: 'docs'
             python: '3.12'
-            command: 'uv run --group docs sphinx-build -b html docs dist/docs && uv run --group docs sphinx-build -b linkcheck docs dist/docs'
+            # -W gates the HTML build on its own warnings, so a broken reference or a
+            # malformed directive fails here instead of shipping. linkcheck reports but
+            # does not gate: whether a reference site answers depends on the runner's
+            # address rather than on the change under review.
+            command: 'uv run --group docs sphinx-build -W -b html docs dist/docs && { uv run --group docs sphinx-build -b linkcheck docs dist/docs || echo "::warning title=linkcheck::external links reported problems - see the log"; }'
             os: 'ubuntu-latest'
           - name: 'py311 (ubuntu)'
             python: '3.11'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,11 +50,15 @@ autodoc_member_order = "bysource"
 # for a weaker one. Sending a browser user agent is not the answer: w3.org rejects
 # that in turn, so the set of reachable hosts only moves around.
 linkcheck_ignore = [
-    # Answer 403 to automated clients.
+    # Answer 403 to automated clients, or to datacenter address ranges. Which hosts
+    # do this varies with the runner's address, so the list is a courtesy that keeps
+    # the report readable rather than the thing keeping the build green.
     r"https://www\.iso\.org/",
     r"https://www\.gs1\.org/",
     r"https://www\.icao\.int/",
     r"https://www\.ssa\.gov/",
+    r"https://www\.cusip\.com/",
+    r"https://docs\.aws\.amazon\.com/",
     # Publishes an AAAA record; CI runners have no IPv6 route, so every request
     # fails with "network is unreachable" regardless of the URL being valid.
     r"https://www\.gnu\.org/",


### PR DESCRIPTION
`main` is red because two reference sites — `docs.aws.amazon.com` and `www.cusip.com` — answer 403 to the CI runner. Both serve 200 to an ordinary client; they refuse datacenter address ranges. Nothing about the documentation changed, and nothing in a future pull request can prevent it happening again: which hosts refuse depends on the runner's address and on their own policy, both of which move without notice. This is the fourth host set to break the build this way.

So the docs job now draws the line where the author actually has control.

**The HTML build gates, and gates harder than before.** It runs under `-W`, so a warning fails it. That closes a real hole: until now a broken `:doc:` reference or a malformed directive produced a warning and exit 0, meaning it passed CI and shipped. Verified both ways — a dangling reference now exits 1, and the current tree builds clean under `-W`.

**linkcheck reports and does not gate.** It still runs on every push, still lists every broken link in the log, and now raises a GitHub warning annotation when it finds problems. It no longer fails the job. This follows the pattern the repository already uses for `bench (advisory)`.

The two refusing hosts join the ignore list alongside the others, so the report stays readable. That list is a courtesy for legibility now, not the thing holding the build up.

Infrastructure only: no documentation content and no library code changes.
