### PR TITLE
fix(ci): install docs dependencies into the environment Read the Docs builds with

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,10 +4,15 @@ build:
   tools:
     python: "3.12"
   jobs:
+    # Read the Docs runs `python -m sphinx` from the virtualenv it created, so the
+    # docs dependencies have to land in that environment. Without
+    # UV_PROJECT_ENVIRONMENT, uv installs them into its own .venv instead and the
+    # build fails with "No module named sphinx". --inexact leaves packages uv does
+    # not manage alone, so the uv installed just above survives the sync.
     install:
       - pip install uv
-      - uv sync --group docs
+      - UV_PROJECT_ENVIRONMENT="$READTHEDOCS_VIRTUALENV_PATH" uv sync --group docs --inexact
     pre_build:
-      - uv run python tools/docs/build.py
+      - UV_PROJECT_ENVIRONMENT="$READTHEDOCS_VIRTUALENV_PATH" uv run python tools/docs/build.py
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
Read the Docs has failed every build since 2026-07-17, which is why the published site still serves the 0.3.0 documentation under the old theme. The site is not stale because the theme is misconfigured — nothing new has been published at all.

The failure is two virtualenvs passing each other:

    python -m sphinx -T -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
    /home/docs/.../envs/latest/bin/python: No module named sphinx

Read the Docs creates its own environment and installs `uv` into it. `uv sync` then creates a *second* environment, `.venv`, in the checkout and installs Sphinx and the docs group there. Read the Docs finally runs `python -m sphinx` from its own environment, which never received Sphinx.

Pointing `UV_PROJECT_ENVIRONMENT` at `$READTHEDOCS_VIRTUALENV_PATH` makes uv install into the environment that actually runs the build. `--inexact` keeps uv from pruning packages it does not manage, so the `uv` installed a moment earlier survives its own sync.

Verified by replaying the platform's job sequence against a clean seeded virtualenv — install, pre_build, then the exact `python -m sphinx` invocation Read the Docs runs. It builds 382 pages, exits 0, and the output carries the current theme with no Alabaster markup. The playground wheel is built and wired into `_static` as expected.

One thing this cannot fix from a config file: the project's default version is pinned to `v0.3.0`, so `https://edify.readthedocs.io/` redirects to `/en/v0.3.0/` regardless of how healthy `latest` is. That is a dashboard setting.
