### PR TITLE
docs: prepare the tree for the 1.0.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,13 +1,14 @@
 
 Changelog
 =========
-1.0.0 (2026-07-17)
+1.0.0 (2026-08-04)
 ------------------
 
 The first stable release. Edify grows from a builder into a full toolkit: a
 library of ready-to-call validators, introspection, serialization, framework
 integrations, and a closed match API — with the builder itself hardened and its
-rough edges filed off. The changes worth knowing before you upgrade are below;
+rough edges filed off, and a documentation site you can run code inside. The
+changes worth knowing before you upgrade are below;
 the :doc:`0.3 → 1.0 guide <upgrading/0.3-to-1.0>` walks each one with
 before/after code.
 
@@ -33,6 +34,14 @@ Breaking
 * Named back-references resolve by name and named groups read off ``.captures``. See :ref:`named-backref-return`.
 * Character-class escaping is minimal and correct: only the metacharacters that need escaping inside a class are escaped. See :ref:`char-class-escape`.
 * The validator library is organised into categories, and a handful of import paths moved with it. See :ref:`library-reorg` and :ref:`moved-import-paths`.
+
+Documentation
+~~~~~~~~~~~~~
+
+* A rebuilt documentation site: a topic-first guide that works through the builder from anchors to lookaround, a page for every one of the 228 validators, and a complete API reference covering the public surface — every method, property, constant, atom, error, and type.
+* An in-browser playground. Examples throughout the guide and the library are live: edit the chain and the emitted regex and match results update as you type, with edify itself running in your browser. The :doc:`playground <playground>` page is the same widget at full size.
+* Every Python example in the documentation is executed by the test suite and snapshotted against the regex it emits, so a documented pattern cannot drift from what the code produces.
+* Method names, constants, and atoms are cross-linked to their reference entries throughout the prose and inside the code samples.
 
 Tooling and CI
 ~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -7,38 +7,31 @@ Edify
 
 |
 
-.. image:: https://readthedocs.org/projects/edify/badge/?style=flat&version=latest
-    :target: https://edify.readthedocs.io/
-    :alt: Documentation
-
-.. image:: https://github.com/luciferreeves/edify/actions/workflows/github-actions.yml/badge.svg?branch=main
-    :target: https://github.com/luciferreeves/edify/actions
-    :alt: Build status
-
-.. image:: https://codecov.io/gh/luciferreeves/edify/branch/main/graph/badge.svg?branch=main
-    :target: https://codecov.io/github/luciferreeves/edify
-    :alt: Coverage
-
-.. image:: https://img.shields.io/pypi/v/edify.svg
-    :target: https://pypi.org/project/edify
-    :alt: PyPI
-
-.. image:: https://img.shields.io/pypi/pyversions/edify.svg
-    :target: https://pypi.org/project/edify
-    :alt: Python versions
-
-.. image:: https://img.shields.io/badge/license-MIT-blue.svg
-    :target: https://github.com/luciferreeves/edify/blob/main/LICENSE
-    :alt: MIT License
-
-.. end-badges
-
-|
-
 **Edify builds regular expressions you can actually read.** It's a fluent,
 immutable regex builder for Python: you describe a pattern step by step in plain
 English, and Edify hands you a compiled regex — one your teammates can review in
 a pull request instead of squinting at.
+
+Why Edify
+=========
+
+A regular expression is easy to write and hard to read. Six months later nobody
+remembers what ``^(?:0x)?([0-9a-fA-F]{4})$`` was meant to accept, and the person
+reviewing the change that touches it has no way to be sure either. The syntax
+gives you nowhere to put a name, a comment, or a seam.
+
+Edify moves the pattern into ordinary Python, where all three fit:
+
+- Methods say what they do. ``.one_or_more().digit()`` needs no decoding.
+- The quantity comes before the thing it counts, the way you say it aloud —
+  ``.exactly(4).digit()`` is *exactly four digits*.
+- Every call returns a new builder, so a pattern you share can be extended in
+  two directions without either one disturbing the other.
+- A mistake raises an error that points at the call that caused it and names the
+  fix, rather than emitting a regex that is subtly wrong.
+
+A first pattern
+===============
 
 .. code-block:: python
 
@@ -57,11 +50,64 @@ a pull request instead of squinting at.
 
     hex_literal.to_regex_string()   # '^(?:0x)?([0-9a-fA-F]{4})$'
     hex_literal.test("0xC0DE")      # True
+    hex_literal.test("0xZZZZ")      # False
 
-Read the chain top to bottom and it says what it does. The quantity comes before
-the thing it counts (*exactly four* of a hex digit), every step returns a new
-builder so nothing you build ever mutates something you built earlier, and if you
-make a mistake Edify raises an error that points at the fix.
+Read the chain top to bottom and it tells you what it accepts.
+
+Patterns you don't have to write
+================================
+
+Edify ships 228 ready-made validators. Each is a callable pattern, so checking a
+value is a function call:
+
+.. code-block:: python
+
+    from edify.library import email, ipv4, semver
+
+    email("a@b.com")      # True
+    semver("1.4.0")       # True
+    ipv4("10.0.0.1")      # True
+    ipv4("999.1.1.1")     # False — the octet range is enforced
+
+They are assembled from 83 named fragments you can build with too, so a pattern
+of your own inherits the same range checks rather than approximating them:
+
+.. code-block:: python
+
+    from edify import Pattern, atoms
+
+    endpoint = (
+        Pattern().start_of_input()
+        .named_capture("host").use(atoms.ipv4).end()
+        .char(":")
+        .named_capture("port").use(atoms.port).end()
+        .end_of_input()
+    )
+
+    endpoint.to_regex().match("10.0.0.1:8080").groupdict()
+    # {'host': '10.0.0.1', 'port': '8080'}
+    endpoint("10.0.0.1:99999")   # False — 99999 is not a port
+
+Ask a pattern what it means
+===========================
+
+Because Edify keeps the structure rather than a string, it can describe a
+pattern back to you — in prose, as a diagram, or as an annotated verbose regex:
+
+.. code-block:: python
+
+    from edify import RegexBuilder
+
+    year = RegexBuilder().start_of_input().exactly(4).digit().end_of_input()
+    print(year.to_regex().explain())
+
+    # - The text must start with exactly 4 digits (0-9).
+    #
+    # Text this pattern accepts:
+    #     1234
+
+That same structure is what lets Edify warn you at build time about a pattern
+shaped for catastrophic backtracking, and round-trip a pattern through JSON.
 
 Install
 =======
@@ -72,28 +118,30 @@ Edify requires **Python 3.11+**:
 
     pip install edify
 
-Optional extras add the third-party regex engine and the framework integrations:
+Optional extras add the alternate regex engine and the framework integrations:
 ``edify[regex]``, ``edify[pydantic]``, ``edify[fastapi]``, ``edify[django]``, or
 ``edify[all]``.
 
-Batteries included
-==================
+Also in the box
+===============
 
-Beyond the builder, Edify ships:
-
-- **228 ready-made validators** — email, URL, semver, IBAN, phone, postal, and
-  hundreds more. Each is a callable pattern: ``from edify.library import email``
-  then ``email("a@b.com")`` returns ``True``.
-- **Introspection** — turn any pattern into a plain-English explanation, an ASCII
-  or Graphviz diagram, or an annotated ``re.VERBOSE`` form.
-- **Serialization** — round-trip a pattern through a dict or JSON.
-- **Integrations** — first-class pydantic, FastAPI, and Django support.
+- **Introspection** — a plain-English explanation, an ASCII or rendered diagram,
+  or an annotated ``re.VERBOSE`` form of any pattern.
+- **Serialization** — round-trip a pattern through a dict or JSON and keep a
+  first-class pattern on the other side, not a flattened string.
+- **Integrations** — pydantic, FastAPI, and Django validators from a pattern.
+- **Testing helpers** — assert a pattern's contract beside its definition, and
+  snapshot what it emits.
+- **Reverse parsing** — turn an existing regex string back into a chain and read
+  what it does.
 
 Documentation
 =============
 
-The full guide, the searchable library, an interactive in-browser playground,
-and the API reference live at `edify.readthedocs.io <https://edify.readthedocs.io>`_.
+`edify.readthedocs.io <https://edify.readthedocs.io>`_ has the guide, a page for
+every validator, and the full API reference. Examples throughout the site are
+live — edit the chain and the emitted regex and match results update as you
+type, with Edify running in your browser.
 
 License and contributing
 ========================


### PR DESCRIPTION
Prepares the tree for tagging 1.0.0.

**Changelog.** The 1.0.0 entry was dated 2026-07-17, about three weeks before the work it now describes finished. It is dated to the release day, and a Documentation section records what the release actually ships on that front: the rebuilt site, the in-browser playground, the fact that every Python example is executed and snapshotted by the test suite, and the cross-linking between prose and reference.

Nothing else needed a changelog entry. The library fixes made since that entry was drafted — range endpoints that carry syntactic weight, inline flags surviving `from_regex`, diagnostics naming the caller's own argument, the validators that were still placeholders — all correct code that has never been released. `edify/builder/mixins/` did not exist at v0.3.0, so from a reader's point of view 1.0.0 simply behaves correctly.

**README.** It had shrunk to roughly a third of the 0.3.0 version and lost the part that explains why the project exists. It now carries the argument — a regex has nowhere to put a name, a comment, or a seam, and that is what makes review impossible — followed by four worked examples: the builder, the ready-made validators, composing with atoms so a pattern of your own inherits the same range checks, and asking a pattern to explain itself. Depth stops there on purpose; every section points at the documentation site rather than reproducing it.

The badge block is gone, as is the framing that credited another project for the API.

Every Python example in the README was extracted and executed, and each claimed output compared against what the code actually returns. Nothing in the repository does this automatically — the docs snapshot suite covers `docs/`, not the README — so it was checked by hand and would need checking again if those examples change.

**Release mechanics verified:**

- A `v1.0.0` tag produces `edify-1.0.0-py3-none-any.whl`. Confirmed by tagging locally, building, and deleting the tag; nothing was pushed.
- The wheel and sdist both build, and `twine check` passes on both, so the README renders on PyPI rather than failing at upload.
- The wheel carries `py.typed` and no stray artifacts; the sdist embeds no built wheel or documentation output.
- The documentation builds clean under `-W`.

Two things remain outside the repository and cannot be done from here: the Read the Docs default version is still pinned to `v0.3.0`, so the bare documentation URL serves the old build until it is changed; and the PyPI trusted publisher has to be configured for this repository and workflow, or the publish job fails on the first release.
