### PR TITLE
docs: restore the README badge block

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,34 @@ Edify
 
 |
 
+.. image:: https://readthedocs.org/projects/edify/badge/?style=flat&version=latest
+    :target: https://edify.readthedocs.io/
+    :alt: Documentation
+
+.. image:: https://github.com/luciferreeves/edify/actions/workflows/github-actions.yml/badge.svg?branch=main
+    :target: https://github.com/luciferreeves/edify/actions
+    :alt: Build status
+
+.. image:: https://codecov.io/gh/luciferreeves/edify/branch/main/graph/badge.svg?branch=main
+    :target: https://codecov.io/github/luciferreeves/edify
+    :alt: Coverage
+
+.. image:: https://img.shields.io/pypi/v/edify.svg
+    :target: https://pypi.org/project/edify
+    :alt: PyPI
+
+.. image:: https://img.shields.io/pypi/pyversions/edify.svg
+    :target: https://pypi.org/project/edify
+    :alt: Python versions
+
+.. image:: https://img.shields.io/badge/license-MIT-blue.svg
+    :target: https://github.com/luciferreeves/edify/blob/main/LICENSE
+    :alt: MIT License
+
+.. end-badges
+
+|
+
 **Edify builds regular expressions you can actually read.** It's a fluent,
 immutable regex builder for Python: you describe a pattern step by step in plain
 English, and Edify hands you a compiled regex — one your teammates can review in


### PR DESCRIPTION
Puts the six badges back at the top of the README — documentation, build status, coverage, PyPI version, supported Python versions, and licence.

They were dropped in #295 on a misreading of "no more badges are required": taken as "badges are not required" rather than "no additional badges are needed". The block is restored byte-for-byte from its state before that commit, so this change is purely additive — 28 insertions, nothing removed, and the prose the same PR added is untouched.

The badge URLs all resolve, the file still parses as reStructuredText, and `twine check` passes on both artifacts, so the long description keeps rendering on PyPI.

One thing this cannot reach: the PyPI page for 1.0.0 keeps the badge-less README, because the long description is captured at upload time. It will pick this up at the next release.
