### PR TITLE
ci: let Dependabot maintain the lockfile and stop its runs failing on coverage upload

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # The "uv" ecosystem — not "pip" — is the one that maintains uv.lock alongside
+  # pyproject.toml. Under "pip" the lockfile was left untouched, and because CI
+  # installs from the lockfile, a bump appeared to pass while still testing the
+  # version it claimed to replace.
+  - package-ecosystem: "uv"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/bench-baseline.yml
+++ b/.github/workflows/bench-baseline.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: install dependencies (includes bench group)
-        run: uv sync --frozen --all-groups
+        run: uv sync --locked --all-groups
       - name: generate baseline.json on the runner
         run: |
           uv run pytest tests/bench/ --benchmark-only --benchmark-json=tests/bench/baseline.json

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,6 +4,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # GitHub withholds Actions secrets from Dependabot-triggered runs, so the token
+    # is empty there and Codecov refuses the upload with "token required because
+    # branch is protected". Reading it through an env var lets the upload step be
+    # skipped in that case: the `secrets` context is not dependable inside a step
+    # `if:`, but `env` is. Runs that do have the token still upload and still fail
+    # hard when the upload breaks.
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -14,10 +22,11 @@ jobs:
       - name: install graphviz system package
         run: sudo apt-get update && sudo apt-get install -y graphviz
       - name: install dependencies
-        run: uv sync --frozen
+        run: uv sync --locked
       - name: run tests with coverage
         run: uv run pytest --cov=edify --cov-report=xml
       - name: upload coverage to codecov
+        if: env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -63,7 +63,7 @@ jobs:
       - name: install graphviz system package
         run: sudo apt-get update && sudo apt-get install -y graphviz
       - name: install dependencies
-        run: uv sync --frozen --all-groups
+        run: uv sync --locked --all-groups
       - name: ${{ matrix.name }}
         run: ${{ matrix.command }}
 
@@ -226,7 +226,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: install dependencies (includes bench group)
-        run: uv sync --frozen --all-groups
+        run: uv sync --locked --all-groups
       - name: run benchmarks against committed baseline (advisory only)
         run: |
           if [ -f tests/bench/baseline.json ]; then

--- a/README.rst
+++ b/README.rst
@@ -19,15 +19,15 @@ Edify
     :target: https://codecov.io/github/luciferreeves/edify
     :alt: Coverage
 
-.. image:: https://img.shields.io/pypi/v/edify.svg
+.. image:: https://img.shields.io/pypi/v/edify
     :target: https://pypi.org/project/edify
     :alt: PyPI
 
-.. image:: https://img.shields.io/pypi/pyversions/edify.svg
+.. image:: https://img.shields.io/pypi/pyversions/edify
     :target: https://pypi.org/project/edify
     :alt: Python versions
 
-.. image:: https://img.shields.io/badge/license-MIT-blue.svg
+.. image:: https://img.shields.io/badge/license-MIT-blue
     :target: https://github.com/luciferreeves/edify/blob/main/LICENSE
     :alt: MIT License
 


### PR DESCRIPTION
Fixes the two ways Dependabot pull requests currently mislead, both of which showed up on #289 and #290.

**The lockfile was never updated.** Dependabot was configured under the `pip` ecosystem, which edits `pyproject.toml` and leaves `uv.lock` alone. CI installs with `uv sync --frozen`, which reads the lockfile and ignores the manifest — so a bump to pyright 1.1.411 installed pyright 1.1.389, went green, and proved nothing. Both of those pull requests needed a lockfile commit by hand before they tested anything.

The `uv` ecosystem maintains `uv.lock` alongside `pyproject.toml`, so the branch Dependabot opens now installs the version it claims to.

`--frozen` becomes `--locked` in every workflow as the backstop. `--frozen` accepts a lockfile that disagrees with the manifest; `--locked` fails on it. Confirmed both ways: the current tree passes, and reintroducing the drift exits 1 instead of quietly installing the wrong version. That failure mode cannot return silently, whatever future tooling does to the manifest.

**Coverage upload failed on every Dependabot run.** GitHub withholds Actions secrets from Dependabot-triggered runs, so `CODECOV_TOKEN` arrives empty and Codecov refuses the upload — `token required because branch is protected` — with `fail_ci_if_error: true` turning that into a red required check on a green pull request.

The token is now read through a job-level environment variable so the upload step can be skipped when it is absent. The `secrets` context is not dependable inside a step `if:`; `env` is. Runs that do have the token upload exactly as before and still fail hard if the upload genuinely breaks, so the check keeps its teeth where it can be enforced.

Neither problem is specific to those two pull requests: every future bump would have hit both.
