### PR TITLE
docs: bring the version switcher and mobile navigation into the site design

### DIFF
--- a/docs/_theme/edify/api.html
+++ b/docs/_theme/edify/api.html
@@ -34,7 +34,12 @@
 ] %}
 {% block content %}
 <div class="wrap api-layout">
-  <aside class="api-nav" aria-label="API navigation">
+  <aside class="api-nav sidenav" aria-label="API navigation">
+    <button class="sidenav-toggle" type="button" aria-expanded="false" aria-controls="sidenav-tree">
+      <span class="sidenav-toggle-label">API</span>
+      <span class="sidenav-caret" aria-hidden="true"></span>
+    </button>
+    <div class="sidenav-inner" id="sidenav-tree">
     {% for group_label, pages in api_groups %}
     <div class="api-nav-title{% if not loop.first %} api-nav-onpage{% endif %}">{{ group_label }}</div>
     <ul class="api-nav-list">
@@ -46,6 +51,7 @@
       {% endfor %}
     </ul>
     {% endfor %}
+    </div>
   </aside>
   <main id="main" class="content api-content" role="main">
     {{ body }}

--- a/docs/_theme/edify/guide.html
+++ b/docs/_theme/edify/guide.html
@@ -2,7 +2,11 @@
 {% block content %}
 <div class="wrap docs-layout">
   <aside class="sidenav lib-sidenav" aria-label="Guide navigation">
-    <div class="sidenav-inner">
+    <button class="sidenav-toggle" type="button" aria-expanded="false" aria-controls="sidenav-tree">
+      <span class="sidenav-toggle-label">Guide</span>
+      <span class="sidenav-caret" aria-hidden="true"></span>
+    </button>
+    <div class="sidenav-inner" id="sidenav-tree">
       {{ library_nav }}
     </div>
   </aside>

--- a/docs/_theme/edify/layout.html
+++ b/docs/_theme/edify/layout.html
@@ -35,7 +35,10 @@
         <img class="brand-logo brand-logo-dark" src="{{ pathto('_static/img/logo-light-on-dark.png', 1) }}" alt="" width="22" height="22">
         EDIFY
       </a>
-      <nav class="navlinks">
+      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="navlinks" aria-label="Open navigation">
+        <span class="nav-toggle-bars" aria-hidden="true"></span>
+      </button>
+      <nav class="navlinks" id="navlinks">
         <a class="{{ 'current' if pagename.startswith('guide/') }}" href="{{ pathto('guide/index') }}">Guide</a>
         <a class="{{ 'current' if pagename.startswith('library/') }}" href="{{ pathto('library/index') }}">Library</a>
         <a class="{{ 'current' if pagename == 'playground' }}" href="{{ pathto('playground') }}">Playground</a>
@@ -84,6 +87,7 @@
   <script src="{{ pathto('_static/js/apipill.js', 1) }}"></script>
   <script src="{{ pathto('_static/js/navscroll.js', 1) }}"></script>
   <script src="{{ pathto('_static/js/versions.js', 1) }}"></script>
+  <script src="{{ pathto('_static/js/mobilenav.js', 1) }}"></script>
   <script src="{{ pathto('_static/js/edify-api.js', 1) }}"></script>
   <script type="module" src="{{ pathto('_static/js/playground.js', 1) }}"></script>
 </body>

--- a/docs/_theme/edify/layout.html
+++ b/docs/_theme/edify/layout.html
@@ -42,6 +42,16 @@
         <a class="{{ 'current' if pagename.startswith('api/') }}" href="{{ pathto('api/index') }}">API</a>
       </nav>
       <span class="grow"></span>
+      <div class="version-switcher" hidden>
+        <button class="version-button" type="button" aria-expanded="false" aria-haspopup="true" title="Switch documentation version">
+          <span class="version-name"></span>
+          <span class="version-caret" aria-hidden="true"></span>
+        </button>
+        <div class="version-menu" hidden>
+          <p class="version-menu-heading">Version</p>
+          <ul class="version-list"></ul>
+        </div>
+      </div>
       <button class="icon-btn theme-toggle" type="button" aria-label="Toggle color theme" title="Toggle light / dark">
         <span class="theme-glyph"></span>
       </button>
@@ -63,6 +73,7 @@
         <a href="{{ pathto('deprecation-policy') }}">Deprecation policy</a>
         <a href="{{ pathto('changelog') }}">Changelog</a>
         <a href="{{ pathto('contributing') }}">Contributing</a>
+        <a class="footer-rtd" href="https://about.readthedocs.com/" rel="noopener" hidden>Hosted by Read the Docs</a>
       </nav>
     </div>
   </footer>
@@ -72,6 +83,7 @@
   <script src="{{ pathto('_static/js/links.js', 1) }}"></script>
   <script src="{{ pathto('_static/js/apipill.js', 1) }}"></script>
   <script src="{{ pathto('_static/js/navscroll.js', 1) }}"></script>
+  <script src="{{ pathto('_static/js/versions.js', 1) }}"></script>
   <script src="{{ pathto('_static/js/edify-api.js', 1) }}"></script>
   <script type="module" src="{{ pathto('_static/js/playground.js', 1) }}"></script>
 </body>

--- a/docs/_theme/edify/library.html
+++ b/docs/_theme/edify/library.html
@@ -2,7 +2,11 @@
 {% block content %}
 <div class="wrap docs-layout">
   <aside class="sidenav lib-sidenav" aria-label="Library navigation">
-    <div class="sidenav-inner">
+    <button class="sidenav-toggle" type="button" aria-expanded="false" aria-controls="sidenav-tree">
+      <span class="sidenav-toggle-label">Library</span>
+      <span class="sidenav-caret" aria-hidden="true"></span>
+    </button>
+    <div class="sidenav-inner" id="sidenav-tree">
       {{ library_nav }}
     </div>
   </aside>

--- a/docs/_theme/edify/page.html
+++ b/docs/_theme/edify/page.html
@@ -2,7 +2,11 @@
 {% block content %}
 <div class="wrap docs-layout">
   <aside class="sidenav" aria-label="Documentation navigation">
-    <div class="sidenav-inner">
+    <button class="sidenav-toggle" type="button" aria-expanded="false" aria-controls="sidenav-tree">
+      <span class="sidenav-toggle-label">Contents</span>
+      <span class="sidenav-caret" aria-hidden="true"></span>
+    </button>
+    <div class="sidenav-inner" id="sidenav-tree">
       {{ toctree(maxdepth=3, includehidden=True, collapse=False, titles_only=True) }}
     </div>
   </aside>

--- a/docs/_theme/edify/static/css/base.css
+++ b/docs/_theme/edify/static/css/base.css
@@ -131,6 +131,49 @@ img { max-width: 100%; }
   border: 1px solid var(--border); padding: 6px 12px; border-radius: 8px; }
 .ghlink:hover { color: var(--fg); border-color: var(--border-strong); text-decoration: none; }
 
+/* ---- version switcher ----
+   Read the Docs injects its own flyout; this replaces it with a control built
+   from the same tokens as the rest of the nav, so it follows the active theme.
+   Both stay hidden until the addons event confirms a published build. */
+readthedocs-flyout { display: none; }
+
+.version-switcher { position: relative; display: inline-flex; }
+.version-switcher[hidden] { display: none; }
+.version-button {
+  display: inline-flex; align-items: center; gap: 7px;
+  font: inherit; font-size: 14px; font-weight: 500;
+  color: var(--muted); background: transparent;
+  border: 1px solid var(--border); border-radius: 8px;
+  padding: 6px 10px; cursor: pointer;
+}
+.version-button:hover { color: var(--fg); border-color: var(--border-strong); }
+.version-button[aria-expanded="true"] { color: var(--fg); border-color: var(--border-strong); }
+.version-name { font-variant-numeric: tabular-nums; }
+.version-caret {
+  width: 0; height: 0; border-left: 4px solid transparent; border-right: 4px solid transparent;
+  border-top: 5px solid currentColor; opacity: 0.7;
+}
+.version-menu {
+  position: absolute; top: calc(100% + 8px); right: 0; z-index: 200;
+  min-width: 168px; padding: 8px;
+  background: var(--bg); border: 1px solid var(--border); border-radius: 10px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.12);
+}
+[data-theme="dark"] .version-menu { box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5); }
+.version-menu[hidden] { display: none; }
+.version-menu-heading {
+  margin: 2px 8px 8px; font-size: 11px; font-weight: 600;
+  letter-spacing: 0.6px; text-transform: uppercase; color: var(--faint);
+}
+.version-list { list-style: none; margin: 0; padding: 0; max-height: 320px; overflow-y: auto; }
+.version-list a {
+  display: block; padding: 6px 8px; border-radius: 6px;
+  font-size: 14px; color: var(--muted); font-variant-numeric: tabular-nums;
+}
+.version-list a:hover { background: var(--surface); color: var(--fg); text-decoration: none; }
+.version-list a.current { color: var(--accent); font-weight: 600; background: var(--accent-weak); }
+.footer-rtd[hidden] { display: none; }
+
 /* ---- docs two-column layout ---- */
 .docs-layout {
   display: grid; grid-template-columns: var(--sidenav-w) minmax(0, 1fr);

--- a/docs/_theme/edify/static/css/base.css
+++ b/docs/_theme/edify/static/css/base.css
@@ -96,7 +96,7 @@ img { max-width: 100%; }
   background: var(--nav-bg); backdrop-filter: saturate(180%) blur(12px);
   border-bottom: 1px solid var(--border);
 }
-.topnav-inner { display: flex; align-items: center; gap: 22px; height: 58px; }
+.topnav-inner { display: flex; align-items: center; gap: 22px; height: 58px; position: relative; }
 .brand {
   font-weight: 800; letter-spacing: 2.5px; font-size: 15px; color: var(--fg);
   display: inline-flex; align-items: center; gap: 8px;
@@ -130,6 +130,19 @@ img { max-width: 100%; }
 .ghlink { color: var(--muted); font-size: 14px; font-weight: 500;
   border: 1px solid var(--border); padding: 6px 12px; border-radius: 8px; }
 .ghlink:hover { color: var(--fg); border-color: var(--border-strong); text-decoration: none; }
+
+/* ---- mobile navigation ----
+   The nav links and the sidebar tree both collapse behind a control below the
+   layout breakpoint, where there is no room to show either in full. */
+.nav-toggle { display: none; }
+.nav-toggle-bars, .nav-toggle-bars::before, .nav-toggle-bars::after {
+  display: block; width: 16px; height: 1.5px; border-radius: 1px;
+  background: currentColor; content: "";
+}
+.nav-toggle-bars { position: relative; }
+.nav-toggle-bars::before { position: absolute; top: -5px; }
+.nav-toggle-bars::after { position: absolute; top: 5px; }
+.sidenav-toggle { display: none; }
 
 /* ---- version switcher ----
    Read the Docs injects its own flyout; this replaces it with a control built
@@ -165,7 +178,7 @@ readthedocs-flyout { display: none; }
   margin: 2px 8px 8px; font-size: 11px; font-weight: 600;
   letter-spacing: 0.6px; text-transform: uppercase; color: var(--faint);
 }
-.version-list { list-style: none; margin: 0; padding: 0; max-height: 320px; overflow-y: auto; }
+.version-list { list-style: none; margin: 0; padding: 0; max-height: min(320px, 55vh); overflow-y: auto; }
 .version-list a {
   display: block; padding: 6px 8px; border-radius: 6px;
   font-size: 14px; color: var(--muted); font-variant-numeric: tabular-nums;
@@ -230,6 +243,47 @@ readthedocs-flyout { display: none; }
 /* ---- responsive ---- */
 @media (max-width: 860px) {
   .docs-layout { grid-template-columns: 1fr; gap: 20px; }
-  .sidenav { position: static; max-height: none; border-bottom: 1px solid var(--border); padding-bottom: 12px; }
-  .navlinks { display: none; }
+
+  .nav-toggle {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 34px; height: 34px; border-radius: 8px; border: 1px solid var(--border);
+    background: transparent; color: var(--muted); cursor: pointer; padding: 0;
+  }
+  .nav-toggle:hover, .nav-toggle[aria-expanded="true"] {
+    color: var(--fg); border-color: var(--border-strong);
+  }
+  .navlinks {
+    display: none; position: absolute; top: calc(100% + 1px); left: 0; right: 0;
+    flex-direction: column; gap: 0; padding: 8px;
+    background: var(--bg); border-bottom: 1px solid var(--border);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.10);
+  }
+  .navlinks.navlinks-open { display: flex; }
+  .navlinks a { padding: 10px 10px; border-radius: 6px; font-size: 15px; }
+  .navlinks a:hover { background: var(--surface); }
+  .navlinks a.current { background: var(--accent-weak); }
+  .navlinks a.current::after { display: none; }
+
+  .sidenav {
+    position: static; max-height: none; border-bottom: 1px solid var(--border);
+    padding-bottom: 12px;
+  }
+  .sidenav-toggle {
+    display: flex; align-items: center; justify-content: space-between; width: 100%;
+    font: inherit; font-size: 14px; font-weight: 600; color: var(--fg);
+    background: var(--surface); border: 1px solid var(--border); border-radius: 8px;
+    padding: 10px 14px; cursor: pointer;
+  }
+  .sidenav-toggle:hover { border-color: var(--border-strong); }
+  .sidenav-caret {
+    width: 0; height: 0; border-left: 4px solid transparent; border-right: 4px solid transparent;
+    border-top: 5px solid currentColor; opacity: 0.7;
+  }
+  .sidenav-toggle[aria-expanded="true"] .sidenav-caret { transform: rotate(180deg); }
+  .sidenav-inner { display: none; max-height: 60vh; overflow-y: auto; padding-top: 12px; }
+  .sidenav-open .sidenav-inner { display: block; }
+
+  /* the base rule wraps; a column that also wraps spills into a second column */
+  .footer-inner { flex-direction: column; flex-wrap: nowrap; align-items: flex-start; gap: 14px; }
+  .footer-links { flex-wrap: wrap; row-gap: 10px; column-gap: 18px; }
 }

--- a/docs/_theme/edify/static/css/content.css
+++ b/docs/_theme/edify/static/css/content.css
@@ -84,6 +84,12 @@
   border-collapse: collapse; width: 100%; margin: 0 0 1.3rem; font-size: 0.92rem;
   border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden;
 }
+/* a wide reference table scrolls inside its own box rather than widening the page */
+@media (max-width: 860px) {
+  .content table.docutils {
+    display: block; width: max-content; max-width: 100%; overflow-x: auto;
+  }
+}
 .content table.docutils th, .content table.docutils td {
   border-bottom: 1px solid var(--border); padding: 8px 12px; text-align: left;
 }

--- a/docs/_theme/edify/static/css/playground.css
+++ b/docs/_theme/edify/static/css/playground.css
@@ -44,9 +44,9 @@
 .pg-count { color: var(--muted); }
 
 /* ---- builder / editor ---- */
-.pg-builder { flex: 1; }
-.pg-editor { flex: 1; display: flex; min-height: 0; }
-.pg-editor .cm-editor { width: 100%; min-height: 168px; background: transparent; }
+.pg-builder { flex: 1; min-width: 0; }
+.pg-editor { flex: 1; display: flex; min-height: 0; min-width: 0; }
+.pg-editor .cm-editor { width: 100%; max-width: 100%; min-height: 168px; background: transparent; }
 .pg-editor .cm-editor.cm-focused { outline: none; }
 .pg-editor .cm-scroller { overflow: auto; font-family: var(--mono); }
 /* selection — belt-and-suspenders alongside the CodeMirror theme */

--- a/docs/_theme/edify/static/js/mobilenav.js
+++ b/docs/_theme/edify/static/js/mobilenav.js
@@ -1,0 +1,59 @@
+(function () {
+  "use strict";
+
+  var navToggle = document.querySelector(".nav-toggle");
+  var navLinks = document.querySelector(".navlinks");
+  var sidenavToggle = document.querySelector(".sidenav-toggle");
+  var sidenav = document.querySelector(".sidenav");
+
+  function wire(button, target, openClass) {
+    if (!button || !target) {
+      return null;
+    }
+    function setOpen(open) {
+      target.classList.toggle(openClass, open);
+      button.setAttribute("aria-expanded", open ? "true" : "false");
+    }
+    button.addEventListener("click", function (event) {
+      event.stopPropagation();
+      setOpen(!target.classList.contains(openClass));
+    });
+    return setOpen;
+  }
+
+  var toggleLabel = document.querySelector(".sidenav-toggle-label");
+  var currentEntry = sidenav && sidenav.querySelector("a.current");
+  if (toggleLabel && currentEntry) {
+    toggleLabel.textContent = currentEntry.textContent.trim();
+  }
+
+  var setNavOpen = wire(navToggle, navLinks, "navlinks-open");
+  var setSideOpen = wire(sidenavToggle, sidenav, "sidenav-open");
+
+  function closeAll() {
+    if (setNavOpen) {
+      setNavOpen(false);
+    }
+    if (setSideOpen) {
+      setSideOpen(false);
+    }
+  }
+
+  document.addEventListener("click", function (event) {
+    if (navLinks && navLinks.contains(event.target)) {
+      return;
+    }
+    if (sidenav && sidenav.contains(event.target) && event.target.tagName !== "A") {
+      return;
+    }
+    closeAll();
+  });
+
+  document.addEventListener("keydown", function (event) {
+    if (event.key === "Escape") {
+      closeAll();
+    }
+  });
+
+  window.addEventListener("resize", closeAll);
+})();

--- a/docs/_theme/edify/static/js/versions.js
+++ b/docs/_theme/edify/static/js/versions.js
@@ -1,0 +1,78 @@
+(function () {
+  "use strict";
+
+  var DISPLAY_NAMES = { latest: "Latest" };
+
+  var switcher = document.querySelector(".version-switcher");
+  var button = switcher && switcher.querySelector(".version-button");
+  var name = switcher && switcher.querySelector(".version-name");
+  var menu = switcher && switcher.querySelector(".version-menu");
+  var list = switcher && switcher.querySelector(".version-list");
+  var credit = document.querySelector(".footer-rtd");
+
+  if (!switcher || !button || !name || !menu || !list) {
+    return;
+  }
+
+  document.addEventListener("readthedocs-addons-data-ready", function (event) {
+    var data = event.detail.data();
+    var versions = (data.versions && data.versions.active) || [];
+    var current = data.versions && data.versions.current;
+    if (!versions.length) {
+      return;
+    }
+    render(versions, current ? current.slug : null);
+    if (credit) {
+      credit.hidden = false;
+    }
+  });
+
+  function displayName(slug) {
+    return DISPLAY_NAMES[slug] || slug;
+  }
+
+  function render(versions, currentSlug) {
+    name.textContent = displayName(currentSlug || versions[0].slug);
+    list.replaceChildren();
+    versions.forEach(function (version) {
+      list.appendChild(itemFor(version, version.slug === currentSlug));
+    });
+    switcher.hidden = false;
+  }
+
+  function itemFor(version, isCurrent) {
+    var item = document.createElement("li");
+    var link = document.createElement("a");
+    link.href = version.urls.documentation;
+    link.textContent = displayName(version.slug);
+    if (isCurrent) {
+      link.classList.add("current");
+      link.setAttribute("aria-current", "true");
+    }
+    item.appendChild(link);
+    return item;
+  }
+
+  function setOpen(open) {
+    menu.hidden = !open;
+    button.setAttribute("aria-expanded", open ? "true" : "false");
+  }
+
+  button.addEventListener("click", function (event) {
+    event.stopPropagation();
+    setOpen(menu.hidden);
+  });
+
+  document.addEventListener("click", function (event) {
+    if (!menu.hidden && !switcher.contains(event.target)) {
+      setOpen(false);
+    }
+  });
+
+  document.addEventListener("keydown", function (event) {
+    if (event.key === "Escape" && !menu.hidden) {
+      setOpen(false);
+      button.focus();
+    }
+  });
+})();

--- a/tests/docs/mobilenav.test.py
+++ b/tests/docs/mobilenav.test.py
@@ -1,0 +1,89 @@
+"""Navigation has to survive a phone-sized screen.
+
+Below the layout breakpoint there is no room for the nav links or the whole
+sidebar tree, so both collapse behind a control. These tests pin the pieces that
+make that work — every template that renders a sidebar needs the toggle, and the
+footer must not be left in a column that also wraps.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_THEME = Path(__file__).parent.parent.parent / "docs" / "_theme" / "edify"
+_BASE_CSS = (_THEME / "static" / "css" / "base.css").read_text(encoding="utf-8")
+_CONTENT_CSS = (_THEME / "static" / "css" / "content.css").read_text(encoding="utf-8")
+_PLAYGROUND_CSS = (_THEME / "static" / "css" / "playground.css").read_text(encoding="utf-8")
+_LAYOUT = (_THEME / "layout.html").read_text(encoding="utf-8")
+_MOBILE_JS = (_THEME / "static" / "js" / "mobilenav.js").read_text(encoding="utf-8")
+
+_SIDEBAR_TEMPLATES = ["page.html", "guide.html", "library.html", "api.html"]
+
+
+def _mobile_block() -> str:
+    start = _BASE_CSS.index("@media (max-width: 860px)")
+    return _BASE_CSS[start:]
+
+
+def test_the_layout_loads_the_mobile_navigation_script():
+    assert "mobilenav.js" in _LAYOUT
+
+
+def test_the_header_carries_a_control_for_the_hidden_nav_links():
+    assert 'class="nav-toggle"' in _LAYOUT
+    assert 'aria-controls="navlinks"' in _LAYOUT
+    assert 'id="navlinks"' in _LAYOUT
+
+
+@pytest.mark.parametrize("template", _SIDEBAR_TEMPLATES)
+def test_every_template_with_a_sidebar_can_collapse_it(template: str):
+    markup = (_THEME / template).read_text(encoding="utf-8")
+    assert 'class="sidenav-toggle"' in markup
+    assert 'class="sidenav-inner"' in markup
+    assert 'aria-controls="sidenav-tree"' in markup
+
+
+def test_the_nav_links_become_a_panel_below_the_breakpoint():
+    block = _mobile_block()
+    assert ".navlinks.navlinks-open { display: flex; }" in block
+    assert ".nav-toggle {" in block
+
+
+def test_the_sidebar_tree_is_collapsed_and_scrollable_below_the_breakpoint():
+    block = _mobile_block()
+    assert ".sidenav-inner { display: none;" in block
+    assert "overflow-y: auto" in block
+    assert ".sidenav-open .sidenav-inner { display: block; }" in block
+
+
+def test_the_toggle_is_labelled_with_the_page_you_are_on():
+    assert 'sidenav.querySelector("a.current")' in _MOBILE_JS
+    assert "toggleLabel.textContent = currentEntry.textContent.trim();" in _MOBILE_JS
+
+
+def test_a_column_footer_does_not_also_wrap_into_a_second_column():
+    block = _mobile_block()
+    assert "flex-direction: column; flex-wrap: nowrap;" in block
+
+
+def test_the_footer_links_wrap_onto_more_than_one_row():
+    assert ".footer-links { flex-wrap: wrap;" in _mobile_block()
+
+
+def test_a_wide_table_scrolls_instead_of_widening_the_page():
+    assert "display: block; width: max-content; max-width: 100%; overflow-x: auto;" in _CONTENT_CSS
+
+
+def test_the_playground_editor_cannot_push_the_page_wider_than_the_screen():
+    assert ".pg-editor { flex: 1; display: flex; min-height: 0; min-width: 0; }" in _PLAYGROUND_CSS
+    assert ".pg-builder { flex: 1; min-width: 0; }" in _PLAYGROUND_CSS
+
+
+def test_the_version_menu_is_bounded_by_the_screen_it_opens_on():
+    assert "max-height: min(320px, 55vh)" in _BASE_CSS
+
+
+def test_the_menus_close_on_escape():
+    assert '"Escape"' in _MOBILE_JS

--- a/tests/docs/versions.test.py
+++ b/tests/docs/versions.test.py
@@ -1,0 +1,74 @@
+"""The version switcher must stay ours, and stay absent when there is nothing to switch.
+
+Read the Docs injects its own flyout into every published page. The theme hides
+it and renders the version list in the navbar instead, from the data the addons
+script publishes. These tests pin the pieces that make that work: drop the script
+tag or the hide rule and the Read the Docs chrome silently comes back.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_THEME = Path(__file__).parent.parent.parent / "docs" / "_theme" / "edify"
+_LAYOUT = (_THEME / "layout.html").read_text(encoding="utf-8")
+_BASE_CSS = (_THEME / "static" / "css" / "base.css").read_text(encoding="utf-8")
+_VERSIONS_JS = (_THEME / "static" / "js" / "versions.js").read_text(encoding="utf-8")
+
+_REQUIRED_HOOKS = [
+    "version-switcher",
+    "version-button",
+    "version-name",
+    "version-menu",
+    "version-list",
+]
+
+
+@pytest.mark.parametrize("hook", _REQUIRED_HOOKS)
+def test_the_layout_provides_every_hook_the_script_looks_up(hook: str):
+    assert f'"{hook}"' in _VERSIONS_JS or f".{hook}" in _VERSIONS_JS
+    assert hook in _LAYOUT
+
+
+def test_the_layout_loads_the_version_script():
+    assert "versions.js" in _LAYOUT
+
+
+def test_the_switcher_starts_hidden_so_a_local_build_shows_nothing():
+    assert '<div class="version-switcher" hidden>' in _LAYOUT
+    assert 'class="footer-rtd"' in _LAYOUT
+    assert "hidden>Hosted by Read the Docs</a>" in _LAYOUT
+
+
+def test_the_default_read_the_docs_flyout_is_hidden():
+    assert "readthedocs-flyout { display: none; }" in _BASE_CSS
+
+
+def test_the_script_reads_the_read_the_docs_addons_event():
+    assert "readthedocs-addons-data-ready" in _VERSIONS_JS
+    assert "event.detail.data()" in _VERSIONS_JS
+
+
+def test_the_script_links_each_version_to_its_documentation_url():
+    assert "version.urls.documentation" in _VERSIONS_JS
+
+
+def test_latest_is_displayed_capitalised_without_changing_its_slug():
+    assert 'DISPLAY_NAMES = { latest: "Latest" }' in _VERSIONS_JS
+    assert "link.href = version.urls.documentation;" in _VERSIONS_JS
+    assert "link.textContent = displayName(version.slug);" in _VERSIONS_JS
+
+
+def test_the_menu_can_be_dismissed_with_the_keyboard():
+    assert "Escape" in _VERSIONS_JS
+    assert "aria-expanded" in _VERSIONS_JS
+
+
+def test_the_switcher_is_styled_from_the_theme_tokens_so_dark_mode_follows():
+    switcher_block = _BASE_CSS[_BASE_CSS.index("readthedocs-flyout") :]
+    switcher_block = switcher_block[: switcher_block.index("/* ---- docs two-column layout")]
+    for token in ["var(--border)", "var(--muted)", "var(--fg)", "var(--accent)", "var(--bg)"]:
+        assert token in switcher_block
+    assert "#fff" not in switcher_block.lower()


### PR DESCRIPTION
Two related pieces of chrome: the version switcher was Read the Docs', and the
site had no working navigation on a phone.

## The version switcher is ours now

Read the Docs appended a `<readthedocs-flyout>` to `<body>` and rendered a dark
`floating container bottom-right` inside a shadow root — its typography, its
corner radius, floating over our flat light site.

It is replaced with a control in the navbar beside the theme toggle, built from
the existing CSS custom properties so the dark theme follows without a second
implementation. The version list comes from the addons data, not the shadow DOM:
the script listens for `readthedocs-addons-data-ready` and reads
`versions.active[]` and `versions.current`.

`latest` displays as `Latest`. That is presentation only — the slug and the
`/en/latest/` URL are untouched.

Both the switcher and a "Hosted by Read the Docs" footer credit stay hidden until
that event fires, so a local build shows neither rather than rendering empty.
The maintainer-only dashboard links and the duplicate search box are not
reproduced; the attribution is, because they host the site.

## The site now works on a phone

**The nav links were unreachable.** `.navlinks` was `display: none` below 860px
with nothing in its place, so Guide, Library, Playground and API simply did not
exist on mobile. They now collapse behind a menu button in the header.

**The sidebar dumped its whole tree above the page.** Opening a guide page meant
scrolling past thirty-odd links to reach the first paragraph. It is now a
collapsed control that names the page you are on — "Quantifiers", not "Guide" —
and opens into a scrollable panel. Every template that renders a sidebar has it,
including the API reference, which uses a different structure and had been
missed.

**The footer links ran off the screen.** The base rule sets `flex-wrap: wrap`;
switching to a column at mobile width made the flex container wrap into a
*second column*, pushing the links to x=196 and 148px past the right edge. The
column now sets `flex-wrap: nowrap` and the links wrap onto two rows within the
screen.

**Two things were widening the whole page**, which is what made the footer look
broken in the first place: a reference table rendered at its natural 450px, and
the playground editor — `.pg-editor` is a flex item, and without `min-width: 0`
it could not shrink below CodeMirror's content width. Both are now contained,
and the document is exactly viewport-width with no horizontal scroll.

**The version list is bounded by the screen it opens on** rather than a fixed
320px, so a short viewport scrolls instead of running off the bottom — the
failure the Read the Docs flyout had, since it pinned itself to the bottom
corner and rendered the list with `overflow-y: visible`.

## Verified in a browser

Driven with Playwright at 390×700 against a real build, in both themes: nav panel
opens and closes and lists all four sections, sidebar opens with its 35 entries
scrolling (62 on the API page), footer wraps to two rows inside the viewport, the
document reports no horizontal scroll, and a 24-version list scrolls within a
320px window while the menu stays on screen. The switcher and credit were
confirmed absent on a local build, where the addons event never fires.

Closes #322
Closes #323
