### PR TITLE
docs: give the mobile footer room and let the title row wrap

### DIFF
--- a/docs/_theme/edify/static/css/base.css
+++ b/docs/_theme/edify/static/css/base.css
@@ -283,7 +283,11 @@ readthedocs-flyout { display: none; }
   .sidenav-inner { display: none; max-height: 60vh; overflow-y: auto; padding-top: 12px; }
   .sidenav-open .sidenav-inner { display: block; }
 
-  /* the base rule wraps; a column that also wraps spills into a second column */
-  .footer-inner { flex-direction: column; flex-wrap: nowrap; align-items: flex-start; gap: 14px; }
-  .footer-links { flex-wrap: wrap; row-gap: 10px; column-gap: 18px; }
+  /* the base rule wraps and fixes a height; a stacked footer needs neither, or
+     the links wrap into a second column and spill out of the footer box */
+  .footer-inner {
+    flex-direction: column; flex-wrap: nowrap; align-items: flex-start;
+    height: auto; gap: 16px; padding-top: 28px; padding-bottom: 28px;
+  }
+  .footer-links { flex-wrap: wrap; row-gap: 12px; column-gap: 20px; }
 }

--- a/docs/_theme/edify/static/css/content.css
+++ b/docs/_theme/edify/static/css/content.css
@@ -36,6 +36,11 @@
 }
 .api-pill:hover { background: var(--accent); color: var(--accent-fg); text-decoration: none; }
 
+/* the pill cannot shrink, so on a narrow screen it drops below the heading */
+@media (max-width: 860px) {
+  .content .title-row { flex-wrap: wrap; gap: 10px; }
+}
+
 .content a.reference.external::after {
   content: "\2197";
   display: inline-block;


### PR DESCRIPTION
Two things left over from the mobile pass, both visible on an iPhone 12.

## The footer content was spilling out of the footer

`.footer-inner` sets `height: 66px`. That is fine for a single row on a desktop,
but the stacked mobile layout needs 88px, so the links rendered outside the
footer's own background — the last one landing past the bottom of the screen with
nothing behind it.

The mobile rule now lets the box size to its content and gives it real padding
(28px top and bottom, 16px between the brand and the links, 12px between wrapped
link rows) instead of inheriting a desktop bar's fixed height. The links wrap
onto two comfortable rows inside the footer.

## The API-reference pill pushed the page sideways at 320px

`.title-row` is a flex row that could not wrap, and `.api-pill` is `flex: none`
with `white-space: nowrap`, so on a 320px screen the heading and the pill
together were 5px wider than the viewport and the whole document scrolled
horizontally.

The title row now wraps below the breakpoint, so the pill drops under the
heading when there is no room beside it.

## Verified

At 320, 375, 390 and 414 wide: no horizontal scroll on any of them, the footer
content fits inside its own box, and every footer link sits within both the
viewport and the footer. Checked in both themes.
