### PR TITLE
docs: opt in to the Read the Docs addons event API

### DIFF
--- a/docs/_theme/edify/layout.html
+++ b/docs/_theme/edify/layout.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="readthedocs-addons-api-version" content="1">
   <title>{% if title %}{{ title|striptags|e }} · {% endif %}{{ project }}</title>
   <script>
     (function () {

--- a/docs/_theme/edify/static/css/base.css
+++ b/docs/_theme/edify/static/css/base.css
@@ -147,8 +147,10 @@ img { max-width: 100%; }
 /* ---- version switcher ----
    Read the Docs injects its own flyout; this replaces it with a control built
    from the same tokens as the rest of the nav, so it follows the active theme.
-   Both stay hidden until the addons event confirms a published build. */
-readthedocs-flyout { display: none; }
+   Both stay hidden until the addons event confirms a published build, and the
+   injected flyout is only hidden once ours has actually rendered — otherwise a
+   page that never receives the event would offer no version switcher at all. */
+.has-version-switcher readthedocs-flyout { display: none; }
 
 .version-switcher { position: relative; display: inline-flex; }
 .version-switcher[hidden] { display: none; }

--- a/docs/_theme/edify/static/js/versions.js
+++ b/docs/_theme/edify/static/js/versions.js
@@ -38,6 +38,7 @@
       list.appendChild(itemFor(version, version.slug === currentSlug));
     });
     switcher.hidden = false;
+    document.documentElement.classList.add("has-version-switcher");
   }
 
   function itemFor(version, isCurrent) {

--- a/tests/docs/versions.test.py
+++ b/tests/docs/versions.test.py
@@ -42,13 +42,18 @@ def test_the_switcher_starts_hidden_so_a_local_build_shows_nothing():
     assert "hidden>Hosted by Read the Docs</a>" in _LAYOUT
 
 
-def test_the_default_read_the_docs_flyout_is_hidden():
-    assert "readthedocs-flyout { display: none; }" in _BASE_CSS
+def test_the_default_flyout_is_hidden_only_once_ours_has_rendered():
+    assert ".has-version-switcher readthedocs-flyout { display: none; }" in _BASE_CSS
+    assert 'classList.add("has-version-switcher")' in _VERSIONS_JS
 
 
 def test_the_script_reads_the_read_the_docs_addons_event():
     assert "readthedocs-addons-data-ready" in _VERSIONS_JS
     assert "event.detail.data()" in _VERSIONS_JS
+
+
+def test_the_page_opts_in_to_the_addons_event_api():
+    assert '<meta name="readthedocs-addons-api-version" content="1">' in _LAYOUT
 
 
 def test_the_script_links_each_version_to_its_documentation_url():


### PR DESCRIPTION
The version switcher never appeared on the published site. The console said why:

```
Uncaught Subscribing to 'readthedocs-addons-data-ready' requires defining the
'<meta name="readthedocs-addons-api-version" content="1" />' tag in the HTML.
```

Read the Docs gates the event API behind an opt-in meta tag. Without it,
`addEventListener("readthedocs-addons-data-ready", ...)` throws at subscribe
time, so the data never arrived and the switcher stayed hidden. Confirmed
against the addons bundle itself, which reads
`meta[name=readthedocs-addons-api-version]` and expects content `1`:

```js
if (void 0 === ut("readthedocs-addons-api-version")) throw "Subscribing to ...";
```

The tag is now in `<head>`.

## The flyout is only hidden once ours is actually rendered

This failed badly rather than gracefully: the CSS hid
`<readthedocs-flyout>` unconditionally, so when our switcher did not render there
was no version switcher on the page at all.

Hiding is now conditional on a `has-version-switcher` class that the script adds
only after it has drawn the list. If the data never arrives — a change in the
addons API, another opt-in requirement, a blocked script — Read the Docs' own
flyout stays as the fallback instead of leaving readers with nothing.

Tests cover both: the meta tag must be present, and the hide rule must be scoped
to the class the script sets.
