### PR TITLE
docs: add the 1.1.1 release notes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,19 @@
 
 Changelog
 =========
+1.1.1 (2026-08-06)
+------------------
+
+A documentation release. The package itself is unchanged — every file under
+``edify/`` is byte-identical to 1.1.0 — so there is nothing to do on upgrade
+unless you read the docs in a browser.
+
+Fixed
+~~~~~
+
+* The version switcher now appears on the published documentation. Read the Docs gates its addons event API behind an opt-in ``<meta name="readthedocs-addons-api-version" content="1">`` tag; without it, subscribing to the event throws and the switcher never received the version list (:pr:`326`).
+* When the version list cannot be reached, Read the Docs' own flyout stays visible as a fallback. It is now hidden only once our switcher has actually rendered, rather than unconditionally (:pr:`326`).
+
 1.1.0 (2026-08-05)
 ------------------
 


### PR DESCRIPTION
Release notes for 1.1.1, which exists to get the version-switcher fix into a
tagged documentation build.

The package is unchanged. Verified rather than assumed: all **441 files under
`edify/`** in a wheel built at this commit are byte-identical to the published
1.1.0 wheel, and nothing outside `docs/`, one test and `uv.lock` has moved since
the tag. The notes say so plainly, so nobody wonders what changed in the code.

The two entries are the meta-tag opt-in that makes the switcher work at all, and
the change that keeps Read the Docs' own flyout as a fallback when our list
cannot be reached.
